### PR TITLE
Base Image Upgrade & Notification Flow Improvements

### DIFF
--- a/.github/workflows/e2e-tests-xray_frontend.yml
+++ b/.github/workflows/e2e-tests-xray_frontend.yml
@@ -88,7 +88,7 @@ jobs:
           node-version: 18.x
 
       - name: Cypress run all tests
-        uses: cypress-io/github-action@v5.6.0 # use the explicit version number
+        uses: cypress-io/github-action@v5.6.1 # use the explicit version number
         with:
           start: npm start
           wait-on: "http://localhost:4200"
@@ -143,7 +143,7 @@ jobs:
           node-version: 18.x
 
       - name: Cypress run all tests
-        uses: cypress-io/github-action@v5.6.0 # use the explicit version number
+        uses: cypress-io/github-action@v5.6.1 # use the explicit version number
         with:
           start: npm start
           wait-on: "http://localhost:4200"
@@ -206,7 +206,7 @@ jobs:
         run: npx playwright install --with-deps webkit
 
       - name: Cypress run all tests
-        uses: cypress-io/github-action@v5.6.0 # use the explicit version number
+        uses: cypress-io/github-action@v5.6.1 # use the explicit version number
         with:
           start: npm start
           wait-on: "http://localhost:4200"

--- a/.github/workflows/publish-documentation.yaml
+++ b/.github/workflows/publish-documentation.yaml
@@ -65,7 +65,7 @@ jobs:
             sed -i -E '/\[.*\]\(#.*\)/ s/_/-/g' "${file}.md"; done
 
       - name: GitHub Pages action
-        uses: peaceiris/actions-gh-pages@v3.9.2
+        uses: peaceiris/actions-gh-pages@v3.9.3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: "./docs/target/generated-docs"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Added
 
+
 ### Changed
+- Refactored messageId of a notification to have own uuid instead of reusing notificationId
+- Changed receive / update edc callbacks to match one seperate method for each process
+- Updated the Notification Publisher to request initial notifications to the /receive endpoint and updates to the related /update endpoint
+- Updated cypress-io/github-action from 5.6.0 to 5.6.1
+- Updated peaceiris/actions-gh-pages from 3.9.2 to 3.9.3
+- Upgraded base image from sha256@2b33ef284e6dc43a61903cef6d36dbce13414a9e5444e2c96cdd5e35123f9903 to: sha256@c26a727c4883eb73d32351be8bacb3e70f390c2c94f078dc493495ed93c60c2f
 
 ## [3.1.1] - 2023-04-04
 

--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ The base images used, to build these demo application images are `eclipse-temuri
 
 Docker Hub:
 - [eclipse-temurin](https://hub.docker.com/_/eclipse-temurin)
-- [17-jre-alpine image](https://hub.docker.com/layers/library/eclipse-temurin/17-jre-alpine/images/sha256-2b33ef284e6dc43a61903cef6d36dbce13414a9e5444e2c96cdd5e35123f9903?context=explore)
+- [17-jre-alpine image](https://hub.docker.com/layers/library/eclipse-temurin/17-jre-alpine/images/sha256-c26a727c4883eb73d32351be8bacb3e70f390c2c94f078dc493495ed93c60c2f?context=explore)
 - [node](https://hub.docker.com/_/node)
 - [18-alpine image](https://hub.docker.com/layers/library/node/18-alpine/images/sha256-19eaf41f3b8c2ac2f609ac8103f9246a6a6d46716cdbe49103fdb116e55ff0cc?context=explore)
 

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -694,7 +694,7 @@
                 <configuration>
                     <from>
                         <image>
-                            eclipse-temurin:17-jre-alpine@sha256:2b33ef284e6dc43a61903cef6d36dbce13414a9e5444e2c96cdd5e35123f9903
+                            eclipse-temurin:17-jre-alpine@sha256:c26a727c4883eb73d32351be8bacb3e70f390c2c94f078dc493495ed93c60c2f
                         </image>
                     </from>
                     <container>

--- a/backend/src/integration/groovy/org/eclipse/tractusx/traceability/investigations/adapters/rest/ReadInvestigationsControllerIT.groovy
+++ b/backend/src/integration/groovy/org/eclipse/tractusx/traceability/investigations/adapters/rest/ReadInvestigationsControllerIT.groovy
@@ -103,11 +103,11 @@ class ReadInvestigationsControllerIT extends IntegrationSpecification implements
 
         and:
         storedNotifications(
-                new NotificationEntity("1", firstInvestigation, senderBPN, senderName, receiverBPN, receiverName, [], null, null, null, null, null),
-                new NotificationEntity("2", secondInvestigation, senderBPN, senderName, receiverBPN, receiverName, [], null, null, null, null, null),
-                new NotificationEntity("3", thirdInvestigation, senderBPN, senderName, receiverBPN, receiverName, [], null, null, null, null, null),
-                new NotificationEntity("4", fourthInvestigation, senderBPN, senderName, receiverBPN, receiverName, [], null, null, null, null, null),
-                new NotificationEntity("5", fifthInvestigation, senderBPN, senderName, receiverBPN, receiverName, [], null, null, null, null, null)
+                new NotificationEntity("1", firstInvestigation, senderBPN, senderName, receiverBPN, receiverName, [], null, null, null, null, null, "messageId"),
+                new NotificationEntity("2", secondInvestigation, senderBPN, senderName, receiverBPN, receiverName, [], null, null, null, null, null, "messageId"),
+                new NotificationEntity("3", thirdInvestigation, senderBPN, senderName, receiverBPN, receiverName, [], null, null, null, null, null, "messageId"),
+                new NotificationEntity("4", fourthInvestigation, senderBPN, senderName, receiverBPN, receiverName, [], null, null, null, null, null, "messageId"),
+                new NotificationEntity("5", fifthInvestigation, senderBPN, senderName, receiverBPN, receiverName, [], null, null, null, null, null, "messageId")
         )
 
         expect:
@@ -179,7 +179,8 @@ class ReadInvestigationsControllerIT extends IntegrationSpecification implements
                     null,
                     null,
                     null,
-                    null
+                    null,
+                    "messageId"
             )
             NotificationEntity persistedNotification = storedNotification(notificationEntity)
             persistedNotification.setInvestigation(investigation);
@@ -224,11 +225,11 @@ class ReadInvestigationsControllerIT extends IntegrationSpecification implements
 
         and:
         storedNotifications(
-                new NotificationEntity("1", firstInvestigation, senderBPN, senderName, receiverBPN, receiverName, [], null, null, null, null, null),
-                new NotificationEntity("2", secondInvestigation, senderBPN, senderName, receiverBPN, receiverName, [], null, null, null, null, null),
-                new NotificationEntity("3", thirdInvestigation, senderBPN, senderName, receiverBPN, receiverName, [], null, null, null, null, null),
-                new NotificationEntity("4", fourthInvestigation, senderBPN, senderName, receiverBPN, receiverName, [], null, null, null, null, null),
-                new NotificationEntity("5", fifthInvestigation, senderBPN, senderName, receiverBPN, receiverName, [], null, null, null, null, null)
+                new NotificationEntity("1", firstInvestigation, senderBPN, senderName, receiverBPN, receiverName, [], null, null, null, null, null, "messageId"),
+                new NotificationEntity("2", secondInvestigation, senderBPN, senderName, receiverBPN, receiverName, [], null, null, null, null, null, "messageId"),
+                new NotificationEntity("3", thirdInvestigation, senderBPN, senderName, receiverBPN, receiverName, [], null, null, null, null, null, "messageId"),
+                new NotificationEntity("4", fourthInvestigation, senderBPN, senderName, receiverBPN, receiverName, [], null, null, null, null, null, "messageId"),
+                new NotificationEntity("5", fifthInvestigation, senderBPN, senderName, receiverBPN, receiverName, [], null, null, null, null, null, "messageId")
         )
 
         expect:
@@ -277,7 +278,7 @@ class ReadInvestigationsControllerIT extends IntegrationSpecification implements
         InvestigationEntity investigationEntity = new InvestigationEntity([], testBpn, "1", InvestigationStatus.RECEIVED, InvestigationSide.SENDER, Instant.now())
         InvestigationEntity persistedInvestigation = storedInvestigationFullObject(investigationEntity)
         and:
-        NotificationEntity notificationEntity = storedNotification(new NotificationEntity("1", investigationEntity, senderBPN, senderName, receiverBPN, receiverName, [], null, null, null, null, null))
+        NotificationEntity notificationEntity = storedNotification(new NotificationEntity("1", investigationEntity, senderBPN, senderName, receiverBPN, receiverName, [], null, null, null, null, null, "messageid"))
         notificationEntity.setInvestigation(persistedInvestigation)
         storedNotification(notificationEntity)
         and:

--- a/backend/src/integration/groovy/org/eclipse/tractusx/traceability/investigations/domain/service/InvestigationsPublisherServiceIT.groovy
+++ b/backend/src/integration/groovy/org/eclipse/tractusx/traceability/investigations/domain/service/InvestigationsPublisherServiceIT.groovy
@@ -68,12 +68,13 @@ class InvestigationsPublisherServiceIT extends IntegrationSpecification implemen
 					Severity.MINOR,
                         "some-id",
                         null,
-                        null
+                        null,
+                        "messageid"
 				)
 			)
 
 		when:
-			investigationsReceiverService.handleNotificationReceiverCallback(notification)
+			investigationsReceiverService.handleNotificationReceive(notification)
 
 		then:
 			assertInvestigationsSize(1)

--- a/backend/src/integration/resources/testdata/edc_notification_classification_unsupported.json
+++ b/backend/src/integration/resources/testdata/edc_notification_classification_unsupported.json
@@ -1,0 +1,19 @@
+{
+	"header": {
+		"notificationId": "cda2d956-fa91-4a75-bb4a-8e5ba39b268a",
+		"senderBPN": "BPNL00000003AXS3",
+		"senderAddress": "https://some-url.com",
+		"recipientBPN": "BPNL00000003AXS3",
+		"classification": "UNSUPPORTED",
+		"severity": "CRITICAL",
+		"relatedNotificationId": "",
+		"status": "SENT",
+		"targetDate": "2099-03-11T22:44:06.333826952Z"
+	},
+	"content": {
+		"information": "Some long description",
+		"listOfAffectedItems": [
+			"urn:uuid:d387fa8e-603c-42bd-98c3-4d87fef8d2bb"
+		]
+	}
+}

--- a/backend/src/main/java/org/eclipse/tractusx/traceability/common/mapper/NotificationMapper.java
+++ b/backend/src/main/java/org/eclipse/tractusx/traceability/common/mapper/NotificationMapper.java
@@ -63,7 +63,8 @@ public class NotificationMapper {
                 Severity.valueOf(edcNotification.getSeverity()),
                 edcNotification.getNotificationId(),
                 null,
-                null
+                null,
+                edcNotification.getMessageId()
         );
     }
 

--- a/backend/src/main/java/org/eclipse/tractusx/traceability/infrastructure/edc/blackbox/Constants.java
+++ b/backend/src/main/java/org/eclipse/tractusx/traceability/infrastructure/edc/blackbox/Constants.java
@@ -38,6 +38,7 @@ public class Constants {
 	public static final String ASSET_KEY_NOTIFICATION_TYPE = "asset:prop:notificationtype";
 	public static final String ASSET_VALUE_QUALITY_INVESTIGATION = "qualityinvestigation";
 	public static final String ASSET_VALUE_NOTIFICATION_METHOD_UPDATE = "update";
+    public static final String ASSET_VALUE_NOTIFICATION_METHOD_RECEIVE = "receive";
 	public static final MediaType JSON = MediaType.get("application/json");
 
 

--- a/backend/src/main/java/org/eclipse/tractusx/traceability/infrastructure/edc/blackbox/EdcController.java
+++ b/backend/src/main/java/org/eclipse/tractusx/traceability/infrastructure/edc/blackbox/EdcController.java
@@ -23,7 +23,9 @@ package org.eclipse.tractusx.traceability.infrastructure.edc.blackbox;
 import io.swagger.v3.oas.annotations.Hidden;
 import org.eclipse.tractusx.traceability.common.config.FeatureFlags;
 import org.eclipse.tractusx.traceability.infrastructure.edc.blackbox.model.EDCNotification;
+import org.eclipse.tractusx.traceability.infrastructure.edc.blackbox.model.NotificationType;
 import org.eclipse.tractusx.traceability.infrastructure.edc.blackbox.validators.ValidEDCNotification;
+import org.eclipse.tractusx.traceability.investigations.domain.model.exception.InvestigationIllegalUpdate;
 import org.eclipse.tractusx.traceability.investigations.domain.service.InvestigationsReceiverService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -55,16 +57,26 @@ public class EdcController {
 	@PostMapping("/qualitynotifications/receive")
 	public void qualityNotificationReceive(final @ValidEDCNotification @Valid @RequestBody EDCNotification edcNotification) {
 		logger.info("EdcController [qualityNotificationReceive] notificationId:{}", edcNotification);
-		investigationsReceiverService.handleNotificationReceiverCallback(edcNotification);
+        validateIsQualityInvestigation(edcNotification);
+		investigationsReceiverService.handleNotificationReceive(edcNotification);
 	}
 
 	/**
-	 * Receiver API call for EDC Transfer
+	 * Update API call for EDC Transfer
 	 */
 	@PostMapping("/qualitynotifications/update")
 	public void qualityNotificationUpdate(final @ValidEDCNotification @Valid @RequestBody EDCNotification edcNotification) {
 		logger.info("EdcController [qualityNotificationUpdate] notificationId:{}", edcNotification);
-		investigationsReceiverService.handleNotificationReceiverCallback(edcNotification);
+        validateIsQualityInvestigation(edcNotification);
+		investigationsReceiverService.handleNotificationUpdate(edcNotification);
 	}
+
+
+    private void validateIsQualityInvestigation(EDCNotification edcNotification) {
+        NotificationType notificationType = edcNotification.convertNotificationType();
+        if (!notificationType.equals(NotificationType.QMINVESTIGATION)) {
+            throw new InvestigationIllegalUpdate("Received %s classified edc notification which is not an investigation".formatted(notificationType));
+        }
+    }
 }
 

--- a/backend/src/main/java/org/eclipse/tractusx/traceability/infrastructure/edc/blackbox/EdcService.java
+++ b/backend/src/main/java/org/eclipse/tractusx/traceability/infrastructure/edc/blackbox/EdcService.java
@@ -68,7 +68,8 @@ public class EdcService {
 	public Optional<ContractOffer> findNotificationContractOffer(
 		String consumerEdcDataManagementUrl,
 		String providerConnectorControlPlaneIDSUrl,
-		Map<String, String> header
+		Map<String, String> header,
+        boolean isInitialNotification
 	) throws IOException {
 		Catalog catalog = httpCallService.getCatalogFromProvider(consumerEdcDataManagementUrl, providerConnectorControlPlaneIDSUrl, header);
 		if (catalog.getContractOffers().isEmpty()) {
@@ -77,8 +78,13 @@ public class EdcService {
 		}
 		logger.info(":::: Find Notification contract method[findNotificationContractOffer] total catalog ::{}", catalog.getContractOffers().size());
 
-		return catalog.getContractOffers().stream()
-			.filter(it -> isPropertyQualityInvestigationType(it.getAsset()) && isPropertyUpdateNotificationMethod(it.getAsset())).findAny();
+        if (isInitialNotification){
+            return catalog.getContractOffers().stream()
+                    .filter(it -> isPropertyQualityInvestigationType(it.getAsset()) && isPropertyReceiveNotificationMethod(it.getAsset())).findAny();
+        } else {
+            return catalog.getContractOffers().stream()
+                    .filter(it -> isPropertyQualityInvestigationType(it.getAsset()) && isPropertyUpdateNotificationMethod(it.getAsset())).findAny();
+        }
 	}
 
 	private boolean isPropertyQualityInvestigationType(Asset asset) {
@@ -92,8 +98,13 @@ public class EdcService {
 		String formatted = String.format(":::: Asset isPropertyUpdateNotificationMethod %s has value %s", "asset:prop:notificationmethod", asset.getPropertyNotificationMethod());
 		logger.info(formatted);
 		return Constants.ASSET_VALUE_NOTIFICATION_METHOD_UPDATE.equals(asset.getPropertyNotificationMethod());
-
 	}
+
+    private boolean isPropertyReceiveNotificationMethod(Asset asset) {
+        String formatted = String.format(":::: Asset isPropertyReceiveNotificationMethod %s has value %s", "asset:prop:notificationmethod", asset.getPropertyNotificationMethod());
+        logger.info(formatted);
+        return Constants.ASSET_VALUE_NOTIFICATION_METHOD_RECEIVE.equals(asset.getPropertyNotificationMethod());
+    }
 
 	/**
 	 * Prepare for contract negotiation. it will wait for while till API return agreementId

--- a/backend/src/main/java/org/eclipse/tractusx/traceability/infrastructure/edc/blackbox/InvestigationsEDCFacade.java
+++ b/backend/src/main/java/org/eclipse/tractusx/traceability/infrastructure/edc/blackbox/InvestigationsEDCFacade.java
@@ -71,7 +71,7 @@ public class InvestigationsEDCFacade {
 		this.edcProperties = edcProperties;
 	}
 
-	public void startEDCTransfer(Notification notification, String receiverEdcUrl, String senderEdcUrl) {
+	public void startEDCTransfer(Notification notification, String receiverEdcUrl, String senderEdcUrl, boolean isInitialNotification) {
 		Map<String, String> header = new HashMap<>();
 		header.put("x-api-key", edcProperties.getApiAuthKey());
 		try {
@@ -81,7 +81,8 @@ public class InvestigationsEDCFacade {
 			Optional<ContractOffer> contractOffer = edcService.findNotificationContractOffer(
 				senderEdcUrl,
 				receiverEdcUrl + edcProperties.getIdsPath(),
-				header
+				header,
+                    isInitialNotification
 			);
 
 			if (contractOffer.isEmpty()) {

--- a/backend/src/main/java/org/eclipse/tractusx/traceability/infrastructure/edc/blackbox/model/EDCNotification.java
+++ b/backend/src/main/java/org/eclipse/tractusx/traceability/infrastructure/edc/blackbox/model/EDCNotification.java
@@ -23,80 +23,88 @@ package org.eclipse.tractusx.traceability.infrastructure.edc.blackbox.model;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+import org.apache.commons.lang3.StringUtils;
 import org.eclipse.tractusx.traceability.investigations.domain.model.AffectedPart;
 import org.eclipse.tractusx.traceability.investigations.domain.model.InvestigationStatus;
 
-import jakarta.validation.Valid;
-import jakarta.validation.constraints.NotNull;
 import java.time.Instant;
 import java.util.List;
 import java.util.stream.Collectors;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public record EDCNotification(@Valid
-							  @NotNull
-							  @Schema(description = "Header of the EDC notification",
-								  implementation = EDCNotificationHeader.class) EDCNotificationHeader header,
-							  @NotNull EDCNotificationContent content) {
+                              @NotNull
+                              @Schema(description = "Header of the EDC notification",
+                                      implementation = EDCNotificationHeader.class) EDCNotificationHeader header,
+                              @NotNull EDCNotificationContent content) {
 
-	@JsonIgnore
-	public String getRecipientBPN() {
-		return header.recipientBPN();
-	}
+    @JsonIgnore
+    public String getRecipientBPN() {
+        return header.recipientBPN();
+    }
 
-	@JsonIgnore
-	public String getNotificationId() {
-		return header.notificationId();
-	}
+    @JsonIgnore
+    public String getNotificationId() {
+        return header.notificationId();
+    }
 
-	@JsonIgnore
-	public String getSenderBPN() {
-		return header.senderBPN();
-	}
+    @JsonIgnore
+    public String getSenderBPN() {
+        return header.senderBPN();
+    }
 
-	@JsonIgnore
-	public String getSenderAddress() {
-		return header.senderAddress();
-	}
+    @JsonIgnore
+    public String getSenderAddress() {
+        return header.senderAddress();
+    }
 
-	@JsonIgnore
-	public String getInformation() {
-		return content.information();
-	}
+    @JsonIgnore
+    public String getInformation() {
+        return content.information();
+    }
 
-	@JsonIgnore
-	public String getSeverity() {
-		return header.severity();
-	}
+    @JsonIgnore
+    public String getSeverity() {
+        return header.severity();
+    }
 
-	@JsonIgnore
-	public String getRelatedNotificationId() {return header.relatedNotificationId(); }
+    @JsonIgnore
+    public String getMessageId() { return header.messageId(); }
 
-	@JsonIgnore
-	public List<AffectedPart> getListOfAffectedItems() {
-		return content.listOfAffectedItems().stream()
-			.map(AffectedPart::new)
-			.collect(Collectors.toList());
-	}
+    @JsonIgnore
+    public String getRelatedNotificationId() {
+        return header.relatedNotificationId();
+    }
 
-	public NotificationType convertNotificationType() {
-		String classification = header().classification();
+    @JsonIgnore
+    public List<AffectedPart> getListOfAffectedItems() {
+        return content.listOfAffectedItems().stream()
+                .map(AffectedPart::new)
+                .collect(Collectors.toList());
+    }
 
-		return NotificationType.fromValue(classification)
-			.orElseThrow(() -> new IllegalArgumentException("%s not supported notification type".formatted(classification)));
-	}
+    public NotificationType convertNotificationType() {
+        String classification = header().classification();
 
-	public InvestigationStatus convertInvestigationStatus() {
-		String investigationStatus = header().status();
+        return NotificationType.fromValue(classification)
+                .orElseThrow(() -> new IllegalArgumentException("%s not supported notification type".formatted(classification)));
+    }
 
-		return InvestigationStatus.fromValue(investigationStatus)
-			.orElseThrow(() -> new IllegalArgumentException("%s not supported investigation status".formatted(investigationStatus)));
-	}
+    public InvestigationStatus convertInvestigationStatus() {
+        String investigationStatus = header().status();
 
-	public Instant getTargetDate() {
-        if (header.targetDate() != null){
+        return InvestigationStatus.fromValue(investigationStatus)
+                .orElseThrow(() -> new IllegalArgumentException("%s not supported investigation status".formatted(investigationStatus)));
+    }
+
+    @JsonIgnore
+    public Instant getTargetDate() {
+        if (header.targetDate() != null && !StringUtils.isBlank(header.targetDate())) {
             return Instant.parse(header.targetDate());
-        } return null;
-	}
+        }
+        return null;
+    }
 }
 

--- a/backend/src/main/java/org/eclipse/tractusx/traceability/infrastructure/edc/blackbox/model/EDCNotificationFactory.java
+++ b/backend/src/main/java/org/eclipse/tractusx/traceability/infrastructure/edc/blackbox/model/EDCNotificationFactory.java
@@ -46,7 +46,7 @@ public class EDCNotificationFactory {
                 notification.getNotificationReferenceId(),
                 notification.getInvestigationStatus().name(),
                 targetDate,
-                notification.getId()
+                notification.getMessageId()
         );
 
         EDCNotificationContent content = new EDCNotificationContent(

--- a/backend/src/main/java/org/eclipse/tractusx/traceability/infrastructure/edc/blackbox/notification/NegotiationInitiateRequestDto.java
+++ b/backend/src/main/java/org/eclipse/tractusx/traceability/infrastructure/edc/blackbox/notification/NegotiationInitiateRequestDto.java
@@ -50,7 +50,6 @@ public class NegotiationInitiateRequestDto {
 		return offer;
 	}
 
-
 	public static final class Builder {
 		private final NegotiationInitiateRequestDto dto;
 

--- a/backend/src/main/java/org/eclipse/tractusx/traceability/infrastructure/jpa/notification/NotificationEntity.java
+++ b/backend/src/main/java/org/eclipse/tractusx/traceability/infrastructure/jpa/notification/NotificationEntity.java
@@ -73,6 +73,7 @@ public class NotificationEntity {
     private LocalDateTime created;
     private LocalDateTime updated;
     private InvestigationStatus status;
+    private String messageId;
 
     public NotificationEntity() {
     }
@@ -88,7 +89,8 @@ public class NotificationEntity {
                               Instant targetDate,
                               Severity severity,
                               String edcNotificationId,
-                              InvestigationStatus status) {
+                              InvestigationStatus status,
+                              String messageId) {
         this.id = id;
         this.investigation = investigation;
         this.senderBpnNumber = senderBpnNumber;
@@ -102,6 +104,7 @@ public class NotificationEntity {
         this.edcNotificationId = edcNotificationId;
         this.created = LocalDateTime.now();
         this.status = status;
+        this.messageId = messageId;
     }
 
     @PreUpdate
@@ -235,5 +238,13 @@ public class NotificationEntity {
 
     public void setStatus(InvestigationStatus status) {
         this.status = status;
+    }
+
+    public void setMessageId(String messageId) {
+        this.messageId = messageId;
+    }
+
+    public String getMessageId() {
+        return messageId;
     }
 }

--- a/backend/src/main/java/org/eclipse/tractusx/traceability/investigations/adapters/jpa/PersistentInvestigationsRepository.java
+++ b/backend/src/main/java/org/eclipse/tractusx/traceability/investigations/adapters/jpa/PersistentInvestigationsRepository.java
@@ -257,7 +257,8 @@ public class PersistentInvestigationsRepository implements InvestigationsReposit
                 notificationEntity.getSeverity(),
                 notificationEntity.getEdcNotificationId(),
                 notificationEntity.getCreated(),
-                notificationEntity.getUpdated()
+                notificationEntity.getUpdated(),
+                notificationEntity.getMessageId()
         );
     }
 
@@ -281,7 +282,8 @@ public class PersistentInvestigationsRepository implements InvestigationsReposit
                 notification.getTargetDate(),
                 notification.getSeverity(),
                 notification.getEdcNotificationId(),
-                notification.getInvestigationStatus()
+                notification.getInvestigationStatus(),
+                notification.getMessageId()
         );
     }
 

--- a/backend/src/main/java/org/eclipse/tractusx/traceability/investigations/domain/model/Notification.java
+++ b/backend/src/main/java/org/eclipse/tractusx/traceability/investigations/domain/model/Notification.java
@@ -48,10 +48,9 @@ public class Notification {
     private String edcNotificationId;
     private LocalDateTime created;
     private LocalDateTime updated;
-
     private Instant targetDate;
-
     private Severity severity;
+    private String messageId;
 
     public Notification(String id,
                         String notificationReferenceId,
@@ -68,7 +67,8 @@ public class Notification {
                         Severity severity,
                         String edcNotificationId,
                         LocalDateTime created,
-                        LocalDateTime updated) {
+                        LocalDateTime updated,
+                        String messageId) {
         this.id = id;
         this.notificationReferenceId = notificationReferenceId;
         this.senderBpnNumber = senderBpnNumber;
@@ -85,6 +85,7 @@ public class Notification {
         this.edcNotificationId = edcNotificationId;
         this.created = created;
         this.updated = updated;
+        this.messageId = messageId;
     }
 
     void changeStatusTo(InvestigationStatus to) {
@@ -216,6 +217,13 @@ public class Notification {
         this.edcNotificationId = edcNotificationId;
     }
 
+    public String getMessageId() {
+        return messageId;
+    }
+
+    public void setMessageId(String messageId) {
+        this.messageId = messageId;
+    }
 
     // Important - receiver and sender will be saved in switched order
     public Notification copyAndSwitchSenderAndReceiver(BPN applicationBpn) {
@@ -226,7 +234,7 @@ public class Notification {
         String senderManufactureName = senderManufacturerName;
 
         // This is needed to make sure that the app can send a message to the receiver and not addresses itself
-        if (applicationBpn.value().equals(receiverBpnNumber)){
+        if (applicationBpn.value().equals(receiverBpnNumber)) {
             receiver = senderBpnNumber;
             sender = receiverBpnNumber;
             receiverManufactureName = senderManufacturerName;
@@ -248,7 +256,8 @@ public class Notification {
                 severity,
                 edcNotificationId,
                 created,
-                updated
+                updated,
+                UUID.randomUUID().toString()
         );
     }
 
@@ -271,6 +280,7 @@ public class Notification {
                 ", updated=" + updated +
                 ", targetDate=" + targetDate +
                 ", severity=" + severity +
+                ", messageId='" + messageId + '\'' +
                 '}';
     }
 }

--- a/backend/src/main/java/org/eclipse/tractusx/traceability/investigations/domain/service/NotificationsService.java
+++ b/backend/src/main/java/org/eclipse/tractusx/traceability/investigations/domain/service/NotificationsService.java
@@ -49,15 +49,15 @@ public class NotificationsService {
 	}
 
 	@Async(value = AssetsAsyncConfig.UPDATE_NOTIFICATION_EXECUTOR)
-	public void updateAsync(Notification notification) {
-        logger.info("::updateAsync::notification {}", notification);
+	public void asyncNotificationExecutor(Notification notification, boolean isInitialNotification) {
+        logger.info("::asyncNotificationExecutor::notification {}", notification);
 		String senderEdcUrl = edcUrlProvider.getSenderUrl();
 
 		List<String> receiverEdcUrls = edcUrlProvider.getEdcUrls(notification.getReceiverBpnNumber());
 
 		for (String receiverEdcUrl : receiverEdcUrls) {
-            logger.info("::updateAsync::notificationToSend {}", notification);
-			edcFacade.startEDCTransfer(notification, receiverEdcUrl, senderEdcUrl);
+            logger.info("::asyncNotificationExecutor::notificationToSend {}", notification);
+			edcFacade.startEDCTransfer(notification, receiverEdcUrl, senderEdcUrl, isInitialNotification);
 			repository.update(notification);
 		}
 	}

--- a/backend/src/main/resources/db/migration/V14__alter_notification_table_add_created_updated_and_status.sql
+++ b/backend/src/main/resources/db/migration/V14__alter_notification_table_add_created_updated_and_status.sql
@@ -1,0 +1,2 @@
+alter table if exists notification
+    add column message_id varchar(255);

--- a/backend/src/test/java/org/eclipse/tractusx/traceability/common/mapper/InvestigationMapperTest.java
+++ b/backend/src/test/java/org/eclipse/tractusx/traceability/common/mapper/InvestigationMapperTest.java
@@ -64,7 +64,8 @@ class InvestigationMapperTest {
                 Severity.MINOR,
                 "1",
                 null,
-                null
+                null,
+                "messageId"
         );
 		when(clock.instant()).thenReturn(Instant.parse("2022-03-01T12:00:00Z"));
 

--- a/backend/src/test/java/org/eclipse/tractusx/traceability/investigations/domain/service/InvestigationsPublisherServiceTest.java
+++ b/backend/src/test/java/org/eclipse/tractusx/traceability/investigations/domain/service/InvestigationsPublisherServiceTest.java
@@ -3,7 +3,12 @@ package org.eclipse.tractusx.traceability.investigations.domain.service;
 import org.eclipse.tractusx.traceability.assets.domain.ports.AssetRepository;
 import org.eclipse.tractusx.traceability.assets.domain.ports.BpnRepository;
 import org.eclipse.tractusx.traceability.common.model.BPN;
-import org.eclipse.tractusx.traceability.investigations.domain.model.*;
+import org.eclipse.tractusx.traceability.investigations.domain.model.AffectedPart;
+import org.eclipse.tractusx.traceability.investigations.domain.model.Investigation;
+import org.eclipse.tractusx.traceability.investigations.domain.model.InvestigationId;
+import org.eclipse.tractusx.traceability.investigations.domain.model.InvestigationStatus;
+import org.eclipse.tractusx.traceability.investigations.domain.model.Notification;
+import org.eclipse.tractusx.traceability.investigations.domain.model.Severity;
 import org.eclipse.tractusx.traceability.investigations.domain.model.exception.InvestigationIllegalUpdate;
 import org.eclipse.tractusx.traceability.investigations.domain.ports.InvestigationsRepository;
 import org.eclipse.tractusx.traceability.testdata.AssetTestDataFactory;
@@ -26,7 +31,13 @@ import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyBoolean;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class InvestigationsPublisherServiceTest {
@@ -57,8 +68,8 @@ class InvestigationsPublisherServiceTest {
 
         // When
         investigationsPublisherService.startInvestigation(
-			BPN.of("bpn-123"),
-			Arrays.asList("asset-1", "asset-2"), "Test investigation", Instant.parse("2022-03-01T12:00:00Z"), Severity.MINOR);
+                BPN.of("bpn-123"),
+                Arrays.asList("asset-1", "asset-2"), "Test investigation", Instant.parse("2022-03-01T12:00:00Z"), Severity.MINOR);
 
         // Then
         verify(assetRepository).getAssetsById(Arrays.asList("asset-1", "asset-2"));
@@ -66,54 +77,54 @@ class InvestigationsPublisherServiceTest {
 
     }
 
-	@Test
-	void testCancelInvestigationSuccessful() {
-		// Given
-		BPN bpn = new BPN("bpn123");
-		Long id = 1L;
-		Investigation investigation = InvestigationTestDataFactory.createInvestigationTestData(InvestigationStatus.CREATED, InvestigationStatus.CREATED);
-		when(investigationsReadService.loadInvestigation(any())).thenReturn(investigation);
-		when(repository.update(investigation)).thenReturn(new InvestigationId(id));
+    @Test
+    void testCancelInvestigationSuccessful() {
+        // Given
+        BPN bpn = new BPN("bpn123");
+        Long id = 1L;
+        Investigation investigation = InvestigationTestDataFactory.createInvestigationTestData(InvestigationStatus.CREATED, InvestigationStatus.CREATED);
+        when(investigationsReadService.loadInvestigation(any())).thenReturn(investigation);
+        when(repository.update(investigation)).thenReturn(new InvestigationId(id));
 
-		// When
-		investigationsPublisherService.cancelInvestigation(bpn, id);
+        // When
+        investigationsPublisherService.cancelInvestigation(bpn, id);
 
-		// Then
-		verify(investigationsReadService).loadInvestigation(new InvestigationId(id));
-		verify(repository).update(investigation);
-		assertEquals(InvestigationStatus.CANCELED, investigation.getInvestigationStatus());
-	}
+        // Then
+        verify(investigationsReadService).loadInvestigation(new InvestigationId(id));
+        verify(repository).update(investigation);
+        assertEquals(InvestigationStatus.CANCELED, investigation.getInvestigationStatus());
+    }
 
-	@Test
-	void testSendInvestigationSuccessful() {
-		// Given
-		final long id = 1L;
-		final BPN bpn = new BPN("bpn123");
-		InvestigationId investigationId = new InvestigationId(1L);
-		Investigation investigation = InvestigationTestDataFactory.createInvestigationTestData(InvestigationStatus.CREATED, InvestigationStatus.CREATED);
-		when(investigationsReadService.loadInvestigation(investigationId)).thenReturn(investigation);
-		when(repository.update(investigation)).thenReturn(investigationId);
+    @Test
+    void testSendInvestigationSuccessful() {
+        // Given
+        final long id = 1L;
+        final BPN bpn = new BPN("bpn123");
+        InvestigationId investigationId = new InvestigationId(1L);
+        Investigation investigation = InvestigationTestDataFactory.createInvestigationTestData(InvestigationStatus.CREATED, InvestigationStatus.CREATED);
+        when(investigationsReadService.loadInvestigation(investigationId)).thenReturn(investigation);
+        when(repository.update(investigation)).thenReturn(investigationId);
 
-		// When
-		investigationsPublisherService.approveInvestigation(bpn, id);
+        // When
+        investigationsPublisherService.approveInvestigation(bpn, id);
 
-		// Then
-		verify(investigationsReadService).loadInvestigation(investigationId);
-		verify(repository).update(investigation);
-		verify(notificationsService).updateAsync(any());
-	}
+        // Then
+        verify(investigationsReadService).loadInvestigation(investigationId);
+        verify(repository).update(investigation);
+        verify(notificationsService).asyncNotificationExecutor(any(), anyBoolean());
+    }
 
-	@Test
-	@DisplayName("Test updateInvestigation is valid")
-	void testUpdateInvestigation() {
+    @Test
+    @DisplayName("Test updateInvestigation is valid")
+    void testUpdateInvestigation() {
 
-		// Given
-		BPN bpn = BPN.of("senderBPN");
-		Long investigationIdRaw = 1L;
-		InvestigationStatus status = InvestigationStatus.ACKNOWLEDGED;
-		String reason = "the update reason";
+        // Given
+        BPN bpn = BPN.of("senderBPN");
+        Long investigationIdRaw = 1L;
+        InvestigationStatus status = InvestigationStatus.ACKNOWLEDGED;
+        String reason = "the update reason";
 
-		List<AffectedPart> affectedParts = List.of(new AffectedPart("partId"));
+        List<AffectedPart> affectedParts = List.of(new AffectedPart("partId"));
         Notification notification = new Notification(
                 "123",
                 "id123",
@@ -130,10 +141,11 @@ class InvestigationsPublisherServiceTest {
                 Severity.MINOR,
                 "123",
                 LocalDateTime.now(),
-                null
+                null,
+                "messageId"
         );
 
-		Notification notification2 = new Notification(
+        Notification notification2 = new Notification(
                 "456",
                 "id123",
                 "senderBPN",
@@ -149,23 +161,24 @@ class InvestigationsPublisherServiceTest {
                 Severity.MINOR,
                 "123",
                 LocalDateTime.now().plusSeconds(10),
-                null
-		);
-		List<Notification> notifications = new ArrayList<>();
-		notifications.add(notification);
-		notifications.add(notification2);
+                null,
+                "messageId"
+        );
+        List<Notification> notifications = new ArrayList<>();
+        notifications.add(notification);
+        notifications.add(notification2);
 
-		Investigation investigationTestData = InvestigationTestDataFactory.createInvestigationTestDataWithNotificationList(InvestigationStatus.RECEIVED, "recipientBPN", notifications);
+        Investigation investigationTestData = InvestigationTestDataFactory.createInvestigationTestDataWithNotificationList(InvestigationStatus.RECEIVED, "recipientBPN", notifications);
 
-		when(investigationsReadService.loadInvestigation(any(InvestigationId.class))).thenReturn(investigationTestData);
+        when(investigationsReadService.loadInvestigation(any(InvestigationId.class))).thenReturn(investigationTestData);
 
-		// When
-		investigationsPublisherService.updateInvestigationPublisher(bpn, investigationIdRaw, status, reason);
+        // When
+        investigationsPublisherService.updateInvestigationPublisher(bpn, investigationIdRaw, status, reason);
 
-		// Then
-		Mockito.verify(repository).update(investigationTestData);
-		Mockito.verify(notificationsService, times(1)).updateAsync(any(Notification.class));
-	}
+        // Then
+        Mockito.verify(repository).update(investigationTestData);
+        Mockito.verify(notificationsService, times(1)).asyncNotificationExecutor(any(Notification.class), anyBoolean());
+    }
 
     @Test
     @DisplayName("Test updateInvestigation accepted is valid")
@@ -194,7 +207,8 @@ class InvestigationsPublisherServiceTest {
                 Severity.MINOR,
                 "123",
                 LocalDateTime.now(),
-                null
+                null,
+                "messageId"
         );
 
         Notification notification2 = new Notification(
@@ -213,7 +227,8 @@ class InvestigationsPublisherServiceTest {
                 Severity.MINOR,
                 "123",
                 LocalDateTime.now().plusSeconds(10),
-                null
+                null,
+                "messageId"
         );
         List<Notification> notifications = new ArrayList<>();
         notifications.add(notification);
@@ -228,7 +243,7 @@ class InvestigationsPublisherServiceTest {
 
         // Then
         Mockito.verify(repository).update(investigationTestData);
-        Mockito.verify(notificationsService, times(1)).updateAsync(any(Notification.class));
+        Mockito.verify(notificationsService, times(1)).asyncNotificationExecutor(any(Notification.class), anyBoolean());
     }
 
     @Test
@@ -258,7 +273,8 @@ class InvestigationsPublisherServiceTest {
                 Severity.MINOR,
                 "123",
                 LocalDateTime.now(),
-                null
+                null,
+                "messageId"
         );
 
         Notification notification2 = new Notification(
@@ -277,7 +293,8 @@ class InvestigationsPublisherServiceTest {
                 Severity.MINOR,
                 "123",
                 LocalDateTime.now().plusSeconds(10),
-                null
+                null,
+                "messageId"
         );
         List<Notification> notifications = new ArrayList<>();
         notifications.add(notification);
@@ -292,7 +309,7 @@ class InvestigationsPublisherServiceTest {
 
         // Then
         Mockito.verify(repository).update(investigationTestData);
-        Mockito.verify(notificationsService, times(1)).updateAsync(any(Notification.class));
+        Mockito.verify(notificationsService, times(1)).asyncNotificationExecutor(any(Notification.class), anyBoolean());
     }
 
     @Test
@@ -322,7 +339,8 @@ class InvestigationsPublisherServiceTest {
                 Severity.MINOR,
                 "123",
                 LocalDateTime.now(),
-                null
+                null,
+                "messageId"
         );
 
         Notification notification2 = new Notification(
@@ -341,7 +359,8 @@ class InvestigationsPublisherServiceTest {
                 Severity.MINOR,
                 "123",
                 LocalDateTime.now().plusSeconds(10),
-                null
+                null,
+                "messageId"
         );
         List<Notification> notifications = new ArrayList<>();
         notifications.add(notification);
@@ -356,21 +375,21 @@ class InvestigationsPublisherServiceTest {
 
         // Then
         Mockito.verify(repository).update(investigationTestData);
-        Mockito.verify(notificationsService, times(1)).updateAsync(any(Notification.class));
+        Mockito.verify(notificationsService, times(1)).asyncNotificationExecutor(any(Notification.class), anyBoolean());
     }
 
-	@Test
-	@DisplayName("Test updateInvestigation is invalid because investigation status transition not allowed")
-	void testUpdateInvestigationInvalid() {
+    @Test
+    @DisplayName("Test updateInvestigation is invalid because investigation status transition not allowed")
+    void testUpdateInvestigationInvalid() {
 
-		// Given
-		BPN bpn = BPN.of("recipientBPN");
-		Long investigationIdRaw = 1L;
-		InvestigationStatus status = InvestigationStatus.CREATED;
-		String reason = "the update reason";
+        // Given
+        BPN bpn = BPN.of("recipientBPN");
+        Long investigationIdRaw = 1L;
+        InvestigationStatus status = InvestigationStatus.CREATED;
+        String reason = "the update reason";
 
-		List<AffectedPart> affectedParts = List.of(new AffectedPart("partId"));
-		Notification notification = new Notification(
+        List<AffectedPart> affectedParts = List.of(new AffectedPart("partId"));
+        Notification notification = new Notification(
                 "123",
                 "id123",
                 "senderBPN",
@@ -386,22 +405,23 @@ class InvestigationsPublisherServiceTest {
                 Severity.MINOR,
                 "123",
                 null,
-                null
-		);
+                null,
+                "messageId"
+        );
 
-		List<Notification> notifications = new ArrayList<>();
-		notifications.add(notification);
+        List<Notification> notifications = new ArrayList<>();
+        notifications.add(notification);
 
-		Investigation investigationTestData = InvestigationTestDataFactory.createInvestigationTestDataWithNotificationList(InvestigationStatus.SENT, "recipientBPN", notifications);
+        Investigation investigationTestData = InvestigationTestDataFactory.createInvestigationTestDataWithNotificationList(InvestigationStatus.SENT, "recipientBPN", notifications);
 
-		when(investigationsReadService.loadInvestigation(any(InvestigationId.class))).thenReturn(investigationTestData);
+        when(investigationsReadService.loadInvestigation(any(InvestigationId.class))).thenReturn(investigationTestData);
 
-		// When
-		assertThrows(InvestigationIllegalUpdate.class, () -> investigationsPublisherService.updateInvestigationPublisher(bpn, investigationIdRaw, status, reason));
+        // When
+        assertThrows(InvestigationIllegalUpdate.class, () -> investigationsPublisherService.updateInvestigationPublisher(bpn, investigationIdRaw, status, reason));
 
-		// Then
-		Mockito.verify(repository, never()).update(investigationTestData);
-		Mockito.verify(notificationsService, never()).updateAsync(any(Notification.class));
-	}
+        // Then
+        Mockito.verify(repository, never()).update(investigationTestData);
+        Mockito.verify(notificationsService, never()).asyncNotificationExecutor(any(Notification.class), anyBoolean());
+    }
 
 }

--- a/backend/src/test/java/org/eclipse/tractusx/traceability/investigations/domain/service/InvestigationsReceiverServiceTest.java
+++ b/backend/src/test/java/org/eclipse/tractusx/traceability/investigations/domain/service/InvestigationsReceiverServiceTest.java
@@ -35,13 +35,16 @@ class InvestigationsReceiverServiceTest {
 	@Mock
 	private InvestigationMapper mockInvestigationMapper;
 
+    @Mock
+    private InvestigationsReadService investigationsReadService;
+
 	@InjectMocks
 	private InvestigationsReceiverService service;
 
 
 	@Test
-	@DisplayName("Test handleNotificationReceiverCallback sent is valid")
-	void testHandleNotificationReceiverCallbackValidSentNotification() {
+	@DisplayName("Test testHandleNotificationReceiveValidSentNotification sent is valid")
+	void testHandleNotificationReceiveValidSentNotification() {
 
 		// Given
 		List<AffectedPart> affectedParts = List.of(new AffectedPart("partId"));
@@ -61,7 +64,8 @@ class InvestigationsReceiverServiceTest {
                 Severity.MINOR,
                 "123",
                 null,
-                null
+                null,
+                "messageId"
         );
 
 		Investigation investigationTestData = InvestigationTestDataFactory.createInvestigationTestData(InvestigationStatus.RECEIVED, InvestigationStatus.RECEIVED, "recipientBPN");
@@ -73,10 +77,178 @@ class InvestigationsReceiverServiceTest {
 		when(mockInvestigationMapper.toInvestigation(any(BPN.class), anyString(), any(Notification.class))).thenReturn(investigationTestData);
 
 		// When
-		service.handleNotificationReceiverCallback(edcNotification);
+		service.handleNotificationReceive(edcNotification);
 		// Then
 		Mockito.verify(mockRepository).save(investigationTestData);
 	}
+
+    @Test
+    @DisplayName("Test testHandleNotificationUpdateValidAcknowledgeNotificationTransition is valid")
+    void testHandleNotificationUpdateValidAcknowledgeNotificationTransition() {
+
+        // Given
+        List<AffectedPart> affectedParts = List.of(new AffectedPart("partId"));
+        Notification notification = new Notification(
+                "123",
+                "id123",
+                "senderBPN",
+                "senderManufacturerName",
+                "recipientBPN",
+                "receiverManufacturerName",
+                "senderAddress",
+                "agreement",
+                "information",
+                InvestigationStatus.ACKNOWLEDGED,
+                affectedParts,
+                Instant.now(),
+                Severity.MINOR,
+                "123",
+                null,
+                null,
+                "messageId"
+        );
+
+
+
+        Investigation investigationTestData = InvestigationTestDataFactory.createInvestigationTestData(InvestigationStatus.RECEIVED, InvestigationStatus.RECEIVED, "recipientBPN");
+        Notification notificationTestData = NotificationTestDataFactory.createNotificationTestData();
+        EDCNotification edcNotification = EDCNotificationFactory.createQualityInvestigation(
+                "it", notification);
+
+        when(mockNotificationMapper.toNotification(edcNotification)).thenReturn(notificationTestData);
+        when(investigationsReadService.loadInvestigationByEdcNotificationId(edcNotification.getNotificationId())).thenReturn(investigationTestData);
+
+        // When
+        service.handleNotificationUpdate(edcNotification);
+        // Then
+        Mockito.verify(mockRepository).update(investigationTestData);
+    }
+
+    @Test
+    @DisplayName("Test testHandleNotificationUpdateValidDeclineNotificationTransition is valid")
+    void testHandleNotificationUpdateValidDeclineNotificationTransition() {
+
+        // Given
+        List<AffectedPart> affectedParts = List.of(new AffectedPart("partId"));
+        Notification notification = new Notification(
+                "123",
+                "id123",
+                "senderBPN",
+                "senderManufacturerName",
+                "recipientBPN",
+                "receiverManufacturerName",
+                "senderAddress",
+                "agreement",
+                "information",
+                InvestigationStatus.DECLINED,
+                affectedParts,
+                Instant.now(),
+                Severity.MINOR,
+                "123",
+                null,
+                null,
+                "messageId"
+        );
+
+
+
+        Investigation investigationTestData = InvestigationTestDataFactory.createInvestigationTestData(InvestigationStatus.ACKNOWLEDGED, InvestigationStatus.ACKNOWLEDGED, "recipientBPN");
+        Notification notificationTestData = NotificationTestDataFactory.createNotificationTestData();
+        EDCNotification edcNotification = EDCNotificationFactory.createQualityInvestigation(
+                "it", notification);
+
+        when(mockNotificationMapper.toNotification(edcNotification)).thenReturn(notificationTestData);
+        when(investigationsReadService.loadInvestigationByEdcNotificationId(edcNotification.getNotificationId())).thenReturn(investigationTestData);
+
+        // When
+        service.handleNotificationUpdate(edcNotification);
+        // Then
+        Mockito.verify(mockRepository).update(investigationTestData);
+    }
+
+    @Test
+    @DisplayName("Test testHandleNotificationUpdateValidAcknowledgeNotification is valid")
+    void testHandleNotificationUpdateValidAcceptedNotificationTransition() {
+
+        // Given
+        List<AffectedPart> affectedParts = List.of(new AffectedPart("partId"));
+        Notification notification = new Notification(
+                "123",
+                "id123",
+                "senderBPN",
+                "senderManufacturerName",
+                "recipientBPN",
+                "receiverManufacturerName",
+                "senderAddress",
+                "agreement",
+                "information",
+                InvestigationStatus.ACCEPTED,
+                affectedParts,
+                Instant.now(),
+                Severity.MINOR,
+                "123",
+                null,
+                null,
+                "messageId"
+        );
+
+
+
+        Investigation investigationTestData = InvestigationTestDataFactory.createInvestigationTestData(InvestigationStatus.ACKNOWLEDGED, InvestigationStatus.ACKNOWLEDGED, "recipientBPN");
+        Notification notificationTestData = NotificationTestDataFactory.createNotificationTestData();
+        EDCNotification edcNotification = EDCNotificationFactory.createQualityInvestigation(
+                "it", notification);
+
+        when(mockNotificationMapper.toNotification(edcNotification)).thenReturn(notificationTestData);
+        when(investigationsReadService.loadInvestigationByEdcNotificationId(edcNotification.getNotificationId())).thenReturn(investigationTestData);
+
+        // When
+        service.handleNotificationUpdate(edcNotification);
+        // Then
+        Mockito.verify(mockRepository).update(investigationTestData);
+    }
+
+    @Test
+    @DisplayName("Test testHandleNotificationUpdateValidAcknowledgeNotification is valid")
+    void testHandleNotificationUpdateValidCloseNotificationTransition() {
+
+        // Given
+        List<AffectedPart> affectedParts = List.of(new AffectedPart("partId"));
+        Notification notification = new Notification(
+                "123",
+                "id123",
+                "senderBPN",
+                "senderManufacturerName",
+                "recipientBPN",
+                "receiverManufacturerName",
+                "senderAddress",
+                "agreement",
+                "information",
+                InvestigationStatus.CLOSED,
+                affectedParts,
+                Instant.now(),
+                Severity.MINOR,
+                "123",
+                null,
+                null,
+                "messageId"
+        );
+
+
+
+        Investigation investigationTestData = InvestigationTestDataFactory.createInvestigationTestData(InvestigationStatus.ACKNOWLEDGED, InvestigationStatus.ACKNOWLEDGED, "senderBPN");
+        Notification notificationTestData = NotificationTestDataFactory.createNotificationTestData();
+        EDCNotification edcNotification = EDCNotificationFactory.createQualityInvestigation(
+                "it", notification);
+
+        when(mockNotificationMapper.toNotification(edcNotification)).thenReturn(notificationTestData);
+        when(investigationsReadService.loadInvestigationByEdcNotificationId(edcNotification.getNotificationId())).thenReturn(investigationTestData);
+
+        // When
+        service.handleNotificationUpdate(edcNotification);
+        // Then
+        Mockito.verify(mockRepository).update(investigationTestData);
+    }
 
 }
 

--- a/backend/src/test/java/org/eclipse/tractusx/traceability/investigations/domain/service/NotificationsServiceTest.java
+++ b/backend/src/test/java/org/eclipse/tractusx/traceability/investigations/domain/service/NotificationsServiceTest.java
@@ -15,6 +15,7 @@ import java.time.Instant;
 import java.util.List;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -62,14 +63,15 @@ class NotificationsServiceTest {
                 Severity.MINOR,
                 null,
                 null,
+                null,
                 null
 		);
 
 		// when
-		notificationsService.updateAsync(notification);
+		notificationsService.asyncNotificationExecutor(notification, false);
 
 		// then
-		verify(edcFacade).startEDCTransfer(any(Notification.class), eq(edcReceiverUrl), eq(edcSenderUrl));
+		verify(edcFacade).startEDCTransfer(any(Notification.class), eq(edcReceiverUrl), eq(edcSenderUrl), anyBoolean());
 	//	verify(repository).update(any(Notification.class));
 	}
 }

--- a/backend/src/test/java/org/eclipse/tractusx/traceability/testdata/InvestigationTestDataFactory.java
+++ b/backend/src/test/java/org/eclipse/tractusx/traceability/testdata/InvestigationTestDataFactory.java
@@ -33,7 +33,8 @@ public class InvestigationTestDataFactory {
                 Severity.MINOR,
                 "1",
                 null,
-                null
+                null,
+                "messageId"
 		));
 
 		return new Investigation(
@@ -104,7 +105,8 @@ public class InvestigationTestDataFactory {
                 Severity.MINOR,
                 "123",
                 null,
-                null
+                null,
+                "messageId"
 		));
 
 		return new Investigation(
@@ -147,7 +149,8 @@ public class InvestigationTestDataFactory {
                 Severity.MINOR,
                 "123",
                 null,
-                null
+                null,
+                "messageId"
         ));
 
         return new Investigation(

--- a/backend/src/test/java/org/eclipse/tractusx/traceability/testdata/NotificationTestDataFactory.java
+++ b/backend/src/test/java/org/eclipse/tractusx/traceability/testdata/NotificationTestDataFactory.java
@@ -28,7 +28,8 @@ public class NotificationTestDataFactory {
                 Severity.MINOR,
                 "123",
                 null,
-                null
+                null,
+                "messageId"
         );
     }
 }


### PR DESCRIPTION

### Changed
- Refactored messageId of a notification to have own uuid instead of reusing notificationId
- Changed receive / update edc callbacks to match one seperate method for each process
- Updated the Notification Publisher to request initial notifications to the /receive endpoint and updates to the related /update endpoint
- Updated cypress-io/github-action from 5.6.0 to 5.6.1
- Updated peaceiris/actions-gh-pages from 3.9.2 to 3.9.3
- Upgraded base image from sha256@2b33ef284e6dc43a61903cef6d36dbce13414a9e5444e2c96cdd5e35123f9903 to: sha256@c26a727c4883eb73d32351be8bacb3e70f390c2c94f078dc493495ed93c60c2f
