### PR TITLE
Updated documentation links and markdown documentation workflow

### DIFF
--- a/.github/workflows/e2e-tests-xray_frontend.yml
+++ b/.github/workflows/e2e-tests-xray_frontend.yml
@@ -88,7 +88,7 @@ jobs:
           node-version: 18.x
 
       - name: Cypress run all tests
-        uses: cypress-io/github-action@v5.6.1 # use the explicit version number
+        uses: cypress-io/github-action@v5.6.2 # use the explicit version number
         with:
           start: npm start
           wait-on: "http://localhost:4200"
@@ -143,7 +143,7 @@ jobs:
           node-version: 18.x
 
       - name: Cypress run all tests
-        uses: cypress-io/github-action@v5.6.1 # use the explicit version number
+        uses: cypress-io/github-action@v5.6.2 # use the explicit version number
         with:
           start: npm start
           wait-on: "http://localhost:4200"
@@ -206,7 +206,7 @@ jobs:
         run: npx playwright install --with-deps webkit
 
       - name: Cypress run all tests
-        uses: cypress-io/github-action@v5.6.1 # use the explicit version number
+        uses: cypress-io/github-action@v5.6.2 # use the explicit version number
         with:
           start: npm start
           wait-on: "http://localhost:4200"

--- a/.github/workflows/publish-documentation.yaml
+++ b/.github/workflows/publish-documentation.yaml
@@ -8,7 +8,6 @@ on:
     paths:
       - 'docs/**'
 
-
 jobs:
   publish:
     # depending on default permission settings for your org (contents being read-only or read-write for workloads), you will have to add permissions
@@ -31,6 +30,11 @@ jobs:
           java-version: '17'
           distribution: 'temurin'
 
+      - name: Setup Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16
+
       - name: Cache maven packages
         uses: actions/cache@v3
         with:
@@ -38,32 +42,52 @@ jobs:
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
           restore-keys: ${{ runner.os }}-m2
 
-#      - name: Build API documentation with Maven
-#        run: |
-#          mvn clean package -pl <<modules>> -DskipTests --batch-mode
-#          cp ../openapi/index.html docs/src/docs/api-specification/index.html
-
       - name: Build with Maven
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
         run: |
           mvn -f docs/pom.xml --batch-mode generate-resources
-
-      - name: Install pandoc
+      - name: Install Asciidoctor Reducer
         run: |
-          sudo apt-get install pandoc
-          which pandoc
-
-      - name: Convert HTML to markdown
-        env:
-          FILES: "administration/administration-guide arc42/full api-specification/api-specification"
+          sudo gem install asciidoctor-reducer
+      - name: Reduce docs
         run: |
-          cd docs/target/generated-docs
-          for file in ${FILES}; do \
-            pandoc -f html -t markdown_strict --wrap=preserve "${file}.html" -o "${file}.md"; \
-            sed -i 's/](#_/](#/' "${file}.md"; \
-            sed -i -E '/\[.*\]\(#.*\)/ s/_/-/g' "${file}.md"; done
-
+          echo $LANG
+          locale
+          asciidoctor-reducer -o docs/target/adminguide.adoc docs/src/docs/administration/administration-guide.adoc
+          asciidoctor-reducer -o docs/target/arc42.adoc docs/src/docs/arc42/full.adoc
+      - name: Download PlantUML jar
+        run: |
+          wget -O plantuml.jar https://sourceforge.net/projects/plantuml/files/plantuml.jar/download
+      - name: Place PlantUML jar in specific path
+        run: |
+          mv plantuml.jar docs/src/diagram-replacer/
+      - name: Extract PNG-Images with PlantUML and replace PlantUML Code inside docs with PNG-Images
+        working-directory: docs/src/diagram-replacer/
+        run: |
+          node extract.js
+          node replace.js
+      - name: Convert to Markdown
+        # currently only specified for adminguide + arc42
+        run: |
+          npx downdoc -o docs/target/generated-docs/adminguide.md docs/src/diagram-replacer/generated-adocs/adminguide.adoc
+          npx downdoc -o docs/target/generated-docs/arc42.md docs/src/diagram-replacer/generated-adocs/arc42.adoc
+      - name: MD files post-processing
+        working-directory: docs/src/post-processing/
+        run: |
+          export REPO=${GITHUB_REPOSITORY#*/}
+          node fix_headers.js
+          node fix_no_emphasis.js
+          node fix_https_links.js
+          node fix_relative_links.js https://$GITHUB_REPOSITORY_OWNER.github.io/$REPO/docs
+      - name: MD linting
+        run: |
+          npm install markdownlint-cli2
+          npx markdownlint-cli2-config docs/.markdownlint.yaml docs/target/generated-docs/adminguide.md
+          npx markdownlint-cli2-config docs/.markdownlint.yaml docs/target/generated-docs/arc42.md
+      - name: Move assets to target directory
+        run: |
+          mv docs/src/diagram-replacer/assets/ docs/target/generated-docs/assets/
       - name: GitHub Pages action
         uses: peaceiris/actions-gh-pages@v3.9.3
         with:

--- a/.github/workflows/veracode_backend.yml
+++ b/.github/workflows/veracode_backend.yml
@@ -37,7 +37,7 @@ jobs:
         run: mvn -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn --batch-mode -DskipTests=true package
 
       - name: Run Veracode Upload And Scan
-        uses: veracode/veracode-uploadandscan-action@0.2.5
+        uses: veracode/veracode-uploadandscan-action@0.2.6
         with:
           appname: 'Traceability-Foss-Backend'
           createprofile: false

--- a/.github/workflows/veracode_frontend.yml
+++ b/.github/workflows/veracode_frontend.yml
@@ -32,7 +32,7 @@ jobs:
       - run: zip -r veracode-scan-target.zip ./
 
       - name: Run Veracode Upload And Scan
-        uses: veracode/veracode-uploadandscan-action@0.2.5
+        uses: veracode/veracode-uploadandscan-action@0.2.6
         with:
           appname: "Traceability-Foss-Frontend"
           createprofile: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Changed
 - Updated Publish documentation workflow to convert and deploy documentation as markdown (.md)
 - Added logic to push image to docker hub for eclipse-tractusx repository
+- Bumped cypress-io/github-action from 5.6.1 to 5.6.2
+- Bumped veracode/veracode-uploadandscan-action@0.2.5 to 0.2.6
+- Updated catena links from readme to reflext tractusx links
 
 ## [3.3.0] - 2023-05-02
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased - x.x.x]
 ### Changed
+- Updated Publish documentation workflow to convert and deploy documentation as markdown (.md)
 - Added logic to push image to docker hub for eclipse-tractusx repository
+
 ## [3.3.0] - 2023-05-02
 ### Added
 - Added tx-root pom for maven multi module project

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Because it uses SVGs, we knew it will perform great. And we are able to have pin
 Clone the source locally:
 
 ```sh
-$ git clone git@github.com:catenax-ng/tx-traceability-foss.git
+$ git clone git@github.com:eclipse-tractusx/traceability-foss.git
 $ cd tx-traceability-foss/frontend
 ```
 
@@ -153,7 +153,7 @@ or can be viewed in the Swagger UI accessing the url: `{projectBasePath}/api/swa
 
 ## Container image
 
-This application provides container images for demonstration purposes.Here you can finde the [BE Images](https://github.com/catenax-ng/tx-traceability-foss/pkgs/container/tx-traceability-foss) and the [FE Images](https://github.com/catenax-ng/tx-traceability-foss/pkgs/container/tx-traceability-foss-frontend).
+This application provides container images for demonstration purposes.Here you can finde the [BE Images](https://hub.docker.com/r/tractusx/traceability-foss) and the [FE Images](https://hub.docker.com/r/tractusx/traceability-foss-frontend).
 The base images used, to build these demo application images are `eclipse-temurin:17-jre-alpine` and `node:18-alpine`
 
 Docker Hub:

--- a/docs/.markdownlint.yaml
+++ b/docs/.markdownlint.yaml
@@ -1,0 +1,36 @@
+#********************************************************************************
+# Copyright (c) 2023 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License, Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0.
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+#*******************************************************************************/
+"default": true
+# Do not restrict line length: https://github.com/DavidAnson/markdownlint/blob/main/doc/Rules.md#MD013
+"MD013": false
+# Allow same content on headlines on siblings: https://github.com/DavidAnson/markdownlint/blob/main/doc/Rules.md#MD024
+"MD024":
+  "siblings_only": true
+# Allow Dashes as list item bullets https://github.com/markdownlint/markdownlint/blob/main/docs/RULES.md#md004---unordered-list-style
+"MD004": false
+# Allow different List indentation than 2 spaces https://github.com/markdownlint/markdownlint/blob/main/docs/RULES.md#md007---unordered-list-indentation
+"MD007": false
+# Do not restrict List that are surrounded by non-blank lines https://github.com/markdownlint/markdownlint/blob/main/docs/RULES.md#md032---lists-should-be-surrounded-by-blank-lines
+"MD032": false
+# Allow Spaces between emphasis markers https://github.com/markdownlint/markdownlint/blob/main/docs/RULES.md#md037---spaces-inside-emphasis-markers
+"MD037": false
+# Do not restrict Code blocks that are surrounded by non-blank lines https://github.com/markdownlint/markdownlint/blob/main/docs/RULES.md#md031---fenced-code-blocks-should-be-surrounded-by-blank-lines
+"MD031": false
+# Allow skipping header levels https://github.com/markdownlint/markdownlint/blob/main/docs/RULES.md#md001---header-levels-should-only-increment-by-one-level-at-a-time
+"MD001": false

--- a/docs/src/diagram-replacer/extract.js
+++ b/docs/src/diagram-replacer/extract.js
@@ -1,0 +1,39 @@
+/********************************************************************************
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0. *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+const fs = require("fs");
+const path = require("path");
+const { spawn } = require("child_process");
+const TARGET_PATH = "../../target/";
+
+fs.readdirSync(TARGET_PATH).forEach((file) => {
+  if (path.extname(file) === ".adoc") {
+    let plantuml = spawn("java", [
+      "-jar",
+      "./plantuml.jar",
+      "-tpng",
+      "../../target/" + file,
+      "-o",
+      `../src/diagram-replacer/assets/${path.parse(file).name}`,
+    ]);
+    plantuml.on("close", (code) => {
+      console.log(`extracted .PNGs from ${file} with code ${code}`);
+    });
+  }
+
+
+});

--- a/docs/src/diagram-replacer/replace.js
+++ b/docs/src/diagram-replacer/replace.js
@@ -1,0 +1,116 @@
+/********************************************************************************
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0. *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+const fs = require("fs");
+const path = require("path");
+const SOURCE_PATH = "../../target/";
+const TARGET_PATH = "./generated-adocs/";
+const IMAGES_PATH = "./assets/";
+
+/**
+ * CAUTION: :imagedir: variables in .adoc get deleted, so that asset references can be properly set
+ */
+
+fs.readdirSync(SOURCE_PATH).forEach((file) => {
+  if (path.extname(file) === ".adoc") {
+    fs.readFile(SOURCE_PATH + file, "utf8", (err, data) => {
+      if (err) throw err;
+
+      let imageList = [];
+      // loop over images in extracted Image Directory of corresponding adoc
+      fs.readdirSync(IMAGES_PATH + path.parse(file).name + "/").forEach(
+        (image) => {
+          // add suffix _000 to the first png that is exported to  by plantuml.jar
+          if (path.parse(image).name === path.parse(file).name) {
+            let renamedImage = path.parse(image).name + "_000.png";
+            fs.renameSync(
+              IMAGES_PATH + path.parse(file).name + "/" + image,
+              IMAGES_PATH +
+                path.parse(file).name +
+                "/" +
+                renamedImage
+            );
+            imageList.push(renamedImage);
+          } else {
+            imageList.push(image);
+          }
+
+        }
+      );
+
+      let ImageDirectoryPathForAdoc = IMAGES_PATH + path.parse(file).name + "/";
+
+      const lines = data.split("\n");
+      let insidePlantUmlBlock = false;
+      let insideMindMapBlock = false;
+      const output = [];
+
+      for (let i = 0; i < lines.length; i++) {
+        // when line starts with plantuml tag replace with corresponding .PNG
+        if (lines[i].startsWith("[plantuml, target=")) {
+          output.push(
+            `image::${ImageDirectoryPathForAdoc + imageList.shift()}[]`
+          );
+        } else if (lines[i].startsWith("@startuml")) {
+          insidePlantUmlBlock = true;
+        } else if (lines[i].startsWith("@enduml")) {
+          insidePlantUmlBlock = false;
+          continue;
+        } else if (insidePlantUmlBlock) {
+          continue;
+        } else if (lines[i].startsWith("@startmindmap")) {
+          insideMindMapBlock = true;
+        } else if (lines[i].startsWith("@endmindmap")) {
+          insideMindMapBlock = false;
+          continue;
+        } else if (insideMindMapBlock) {
+          continue;
+        } else if (lines[i].startsWith(":imagesdir:")) {
+          continue;
+        } else {
+          output.push(lines[i]);
+        }
+
+        // delete empty black box
+        if (
+          output[output.length - 1] === "...." &&
+          output[output.length - 2] === "...."
+        ) {
+          output.pop();
+          output.pop();
+        }
+      }
+
+      // create target directory for adoc with pngs if not existant
+      if (!fs.existsSync(TARGET_PATH)) {
+        fs.mkdirSync(TARGET_PATH);
+      }
+
+      fs.writeFile(
+        `${TARGET_PATH}${file}`,
+        output.join("\n"),
+        "utf8",
+        (err) => {
+          if (err) throw err;
+          console.log(
+            `successfully replaced PlantUML Code inside ${file} with .PNG Images`
+          );
+        }
+      );
+    });
+  }
+});

--- a/docs/src/docs/arc42/quality/quality-tree.adoc
+++ b/docs/src/docs/arc42/quality/quality-tree.adoc
@@ -2,7 +2,7 @@
 
 The tree structure provides an overview for a sometimes large number of quality requirements.
 
-[plantuml, target=business-context, format=svg]
+[plantuml, target=business-context-2, format=svg]
 ....
 include::../../../uml-diagrams/arc42/quality/quality-tree.puml[]
 ....

--- a/docs/src/post-processing/fix_headers.js
+++ b/docs/src/post-processing/fix_headers.js
@@ -1,0 +1,84 @@
+/********************************************************************************
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0. *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+const fs = require("fs");
+const path = require("path");
+const PATH_TO_MD_FILES = "../../target/generated-docs/";
+
+fs.readdirSync(PATH_TO_MD_FILES).forEach((file) => {
+  if (path.extname(file) === ".md") {
+    fs.readFile(PATH_TO_MD_FILES + file, "utf8", (err, data) => {
+      if (err) throw err;
+
+      const lines = data.split("\n");
+      const output = [];
+
+      let isYaml = false;
+
+      for (let i = 0; i < lines.length; i++) {
+        if (lines[i].startsWith("```yaml")) {
+          isYaml = true;
+        } else if (lines[i].startsWith("```")) {
+          isYaml = false;
+        }
+
+        if (lines[i].startsWith("##### ") && !isYaml) {
+          // replace 5th level to 6th
+          lines[i] = lines[i].replace("##### ", "###### ");
+        }
+        if (lines[i].startsWith("#### ") && !isYaml) {
+          // replace 4th level to 5th
+          lines[i] = lines[i].replace("#### ", "##### ");
+        }
+        if (lines[i].startsWith("### ") && !isYaml) {
+          // replace 3rd level to 4th
+          lines[i] = lines[i].replace("### ", "#### ");
+        }
+        if (lines[i].startsWith("## ") && !isYaml) {
+          // replace 2nd level to 3rd
+          lines[i] = lines[i].replace("## ", "### ");
+        }
+        if (lines[i].startsWith("# ") && i > 0  && !isYaml) {
+          // replace first level headings with second level
+          lines[i] = lines[i].replace("# ", "## ");
+        }
+        // when line starts with hashtag add new line after
+        if (lines[i].startsWith("#") && (typeof lines[i+1] !== 'undefined')) {
+          output.push(lines[i]);
+          if (lines[i+1] !== "" && !isYaml) {
+            output.push("");
+          }
+        } else {
+          output.push(lines[i]);
+        }
+
+      }
+
+      fs.writeFile(
+        `${PATH_TO_MD_FILES}${file}`,
+        output.join("\n"),
+        "utf8",
+        (err) => {
+          if (err) throw err;
+          console.log(
+            `successfully fix headers in ${file}`
+          );
+        }
+      );
+    });
+  }
+});

--- a/docs/src/post-processing/fix_https_links.js
+++ b/docs/src/post-processing/fix_https_links.js
@@ -1,0 +1,71 @@
+/********************************************************************************
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0. *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+const fs = require("fs");
+const path = require("path");
+const PATH_TO_MD_FILES = "../../target/generated-docs/";
+
+fs.readdirSync(PATH_TO_MD_FILES).forEach((file) => {
+  if (path.extname(file) === ".md") {
+    fs.readFile(PATH_TO_MD_FILES + file, "utf8", (err, data) => {
+      if (err) throw err;
+
+      const lines = data.split("\n");
+      const output = [];
+
+      let isYaml = false;
+
+      for (let i = 0; i < lines.length; i++) {
+        if (lines[i].startsWith("```yaml")) {
+          isYaml = true;
+        } else if (lines[i].startsWith("```")) {
+          isYaml = false;
+        }
+
+        // when line contains https without marks around we need to add <> before and after (MD034 - Bare URL used)
+        if (!isYaml && lines[i].includes(" https://") || lines[i].startsWith("https://") || lines[i].includes("\"https://")) {
+          const firstIndex = lines[i].indexOf("https://");
+          const lastIndex = lines[i].indexOf(" ", firstIndex + 1);
+          const fixFirst = lines[i].replace("https://", "<https://");
+          let afterReplacement;
+          if (lastIndex === -1) {
+            afterReplacement = fixFirst + ">";
+          } else {
+            afterReplacement = fixFirst.slice(0, lastIndex + 1) + ">" + fixFirst.slice(lastIndex + 1);
+          }
+
+          output.push(afterReplacement);
+        } else {
+          output.push(lines[i]);
+        }
+
+      }
+
+      fs.writeFile(
+        `${PATH_TO_MD_FILES}${file}`,
+        output.join("\n"),
+        "utf8",
+        (err) => {
+          if (err) throw err;
+          console.log(
+            `successfully fix https links ${file}`
+          );
+        }
+      );
+    });
+  }
+});

--- a/docs/src/post-processing/fix_no_emphasis.js
+++ b/docs/src/post-processing/fix_no_emphasis.js
@@ -1,0 +1,76 @@
+/********************************************************************************
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0. *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+const fs = require("fs");
+const path = require("path");
+const PATH_TO_MD_FILES = "../../target/generated-docs/";
+
+fs.readdirSync(PATH_TO_MD_FILES).forEach((file) => {
+  if (path.extname(file) === ".md") {
+    fs.readFile(PATH_TO_MD_FILES + file, "utf8", (err, data) => {
+      if (err) throw err;
+
+      const lines = data.split("\n");
+      const output = [];
+      let inCodeBlock = false;
+
+      for (let i = 0; i < lines.length; i++) {
+        // when line starts from _ and end with _ script will remove it (MD036 - Emphasis used instead of a heading)
+        if (lines[i].startsWith("_") || lines[i].endsWith("_")) {
+          output.push(lines[i].replace("_", "").replace("_", ""));
+        // fix for MD033 - Inline HTML
+        } else if (lines[i].startsWith("#### <") || lines[i].startsWith("##### <")) {
+          output.push(lines[i].replace(" <", " ").replace(">", ""));
+        // fix for MD040/fenced-code-language: Fenced code blocks should have a language specified, put bash as default
+        } else if (lines[i].startsWith("```")) {
+          if (inCodeBlock) {
+            // end of block, just put ``` again
+            inCodeBlock = false;
+            output.push(lines[i]);
+          } else {
+            inCodeBlock = true;
+            if (lines[i + 1].startsWith("@startjson")) {
+              output.push("");
+              output.push("```json");
+            } else if (!lines[i].endsWith("yaml") && !lines[i].endsWith("json")) {
+              output.push("```bash");
+            } else {
+              output.push(lines[i]);
+            }
+          }
+        } else if (lines[i].startsWith("@startjson") || lines[i].startsWith("skinparam")) {
+          // do not put it to md
+        } else {
+          output.push(lines[i]);
+        }
+
+      }
+
+      fs.writeFile(
+        `${PATH_TO_MD_FILES}${file}`,
+        output.join("\n"),
+        "utf8",
+        (err) => {
+          if (err) throw err;
+          console.log(
+            `successfully emphasis used instead of heading ${file}`
+          );
+        }
+      );
+    });
+  }
+});

--- a/docs/src/post-processing/fix_relative_links.js
+++ b/docs/src/post-processing/fix_relative_links.js
@@ -1,0 +1,56 @@
+/********************************************************************************
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0. *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+const fs = require("fs");
+const path = require("path");
+const PATH_TO_MD_FILES = "../../target/generated-docs/";
+const args = process.argv.slice(2);
+
+fs.readdirSync(PATH_TO_MD_FILES).forEach((file) => {
+  if (path.extname(file) === ".md") {
+    fs.readFile(PATH_TO_MD_FILES + file, "utf8", (err, data) => {
+      if (err) throw err;
+
+      const lines = data.split("\n");
+      const output = [];
+
+      for (let i = 0; i < lines.length; i++) {
+        // when line contains https without marks around we need to add <> before and after (MD034 - Bare URL used)
+        if (lines[i].includes("](./")) {
+          const fixedLine = lines[i].replace("](./", "](" + args[0] + "/");
+
+          output.push(fixedLine);
+        } else {
+          output.push(lines[i]);
+        }
+
+      }
+
+      fs.writeFile(
+        `${PATH_TO_MD_FILES}${file}`,
+        output.join("\n"),
+        "utf8",
+        (err) => {
+          if (err) throw err;
+          console.log(
+            `successfully replaced relative links ${file}`
+          );
+        }
+      );
+    });
+  }
+});

--- a/frontend/INSTALL.md
+++ b/frontend/INSTALL.md
@@ -75,7 +75,7 @@ ingress:
 Add the Trace-X frontend Helm repository:
 
 ```sh
-$ helm repo add traceability-foss-frontend https://catenax-ng.github.io/tx-traceability-foss-frontend
+$ helm repo add traceability-foss-frontend https://github.com/eclipse-tractusx/traceability-foss
 ```
 
 Then install the Helm chart into your cluster:
@@ -93,7 +93,7 @@ dependencies:
   - name: traceability-foss-frontend
     alias: frontend
     version: x.x.x
-    repository: 'https://catenax-ng.github.io/tx-traceability-foss-frontend/'
+    repository: 'https://github.com/eclipse-tractusx/traceability-foss/'
 ```
 
 Then provide your configuration as the values.yaml of that chart.


### PR DESCRIPTION
### Changed
- Updated Publish documentation workflow to convert and deploy documentation as markdown (.md)
- Bumped cypress-io/github-action from 5.6.1 to 5.6.2
- Bumped veracode/veracode-uploadandscan-action@0.2.5 to 0.2.6
- Updated catena links from readme to reflext tractusx links