### PR TITLE
Adjusted cucumber test action not to duplicate execution of repository and jira downloaded feature files

### DIFF
--- a/.github/workflows/xray-cucumber.yaml
+++ b/.github/workflows/xray-cucumber.yaml
@@ -58,6 +58,13 @@ jobs:
           [[ $HTTP_RESULT == 200 || $HTTP_RESULT == 400 ]]
           echo "::set-output name=http_response::$HTTP_RESULT"
 
+      # Required step due to fact that jira will name feature files differently with each feature added and that will cause duplicate test runs
+      - name: Cleanup repository feature files
+        if: ${{ steps.download.outputs.http_response == '200' }}
+        working-directory: tx-cucumber-tests
+        run: |
+          rm -r src/test/resources/features/*
+
       - name: Build with Maven
         if: ${{ steps.download.outputs.http_response == '200' }}
         env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,15 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased - x.x.x]
+## [Unreleased]
+
+### Added
+
+### Changed
+
+### Removed
+
+## [4.1.0] - 2023-06-26
 
 ### Added
 

--- a/tx-cucumber-tests/src/test/java/org/eclipse/tractusx/traceability/test/TraceabilityTestStepDefinition.java
+++ b/tx-cucumber-tests/src/test/java/org/eclipse/tractusx/traceability/test/TraceabilityTestStepDefinition.java
@@ -71,8 +71,11 @@ public class TraceabilityTestStepDefinition {
     public void iCreateQualityInvestigation(DataTable dataTable) {
         final Map<String, String> input = normalize(dataTable.asMap());
         final String assetId = "urn:uuid:7eeeac86-7b69-444d-81e6-655d0f1513bd";
+
         notificationDescription = wrapStringWithTimestamp(input.get("description"));
-        final Instant targetDate = Instant.parse(input.get("targetDate"));
+
+        final Instant targetDate = input.get("targetDate") == null ? null : Instant.parse(input.get("targetDate"));
+
         final String severity = input.get("severity");
 
         final QualityNotificationIdResponse idResponse = restProvider.createInvestigation(

--- a/tx-cucumber-tests/src/test/resources/features/1_TRACEFOSS-1125.feature
+++ b/tx-cucumber-tests/src/test/resources/features/1_TRACEFOSS-1125.feature
@@ -37,24 +37,21 @@ Feature: ⭐[BE] User select severity for Quality Investigation
   Scenario Outline: [BE] Check correct processing of severity in quality investigation
     When I am logged into TRACE_X_A application
     And I create quality investigation
-      | "severity"    | <severity>                    |
-      | "description" | "Hello"                       |
-      | "targetDate"  | "2099-03-11T22:44:06.333827Z" |
+      | "severity"    | <severity>                        |
+      | "description" | "Testing severity TRACEFOSS-1220" |
     Then I check, if quality investigation has proper values
-      | "severity"    | <severity>                    |
-      | "description" | "Hello"                       |
-      | "targetDate"  | "2099-03-11T22:44:06.333827Z" |
-      | "status"      | "CREATED"                     |
+      | "severity"    | <severity>                        |
+      | "description" | "Testing severity TRACEFOSS-1220" |
+      | "status"      | "CREATED"                         |
     When I approve quality investigation
     Then I check, if quality investigation has proper values
       | "status" | "SENT" |
     When I am logged into TRACE_X_B application
     Then I check, if quality investigation has been received
     Then I check, if quality investigation has proper values
-      | "severity"    | <severity>                    |
-      | "description" | "Hello"                       |
-      | "targetDate"  | "2099-03-11T22:44:06.333827Z" |
-      | "status"      | "RECEIVED"                    |
+      | "severity"    | <severity>                        |
+      | "description" | "Testing severity TRACEFOSS-1220" |
+      | "status"      | "RECEIVED"                        |
     When I acknowledge quality investigation
     Then I check, if quality investigation has proper values
       | "status" | "ACKNOWLEDGED" |

--- a/tx-cucumber-tests/src/test/resources/features/2_TRACEFOSS-608.feature
+++ b/tx-cucumber-tests/src/test/resources/features/2_TRACEFOSS-608.feature
@@ -1,0 +1,32 @@
+@TRACEFOSS-608
+Feature: ⭐[TEST] [BE] Set and show notification target date
+	#*As a* User
+	#*I want to* be able to set a target date for my notification while creating it
+	#*so that* I am able to monitor if a reply was given in time.
+	#
+	#h2. Hints
+	#[Concept | https://confluence.catena-x.net/pages/viewpage.action?pageId=69429778]
+
+	#Check if *targetDate* is processed correctly for created quality investigations which contains following checks:
+	#* correct sending of _targetDate_
+	#* correct reception on receiver side
+  @TRACEFOSS-1216 @TRACEFOSS-1673 @TRACEFOSS-1139 @TRACEFOSS-1138 @TRACEFOSS-1101 @INTEGRATION_TEST
+  Scenario: [BE] Check correct processing of targetDate in quality investigation
+    When I am logged into TRACE_X_A application
+    And I create quality investigation
+      | "severity"    | "MINOR"                             |
+      | "description" | "Testing targetDate TRACEFOSS-1216" |
+      | "targetDate"  | "2099-03-11T22:44:06.333827Z"       |
+    Then I check, if quality investigation has proper values
+      | "description" | "Testing targetDate TRACEFOSS-1216" |
+      | "targetDate"  | "2099-03-11T22:44:06.333827Z"       |
+      | "status"      | "CREATED"                           |
+    When I approve quality investigation
+    Then I check, if quality investigation has proper values
+      | "status" | "SENT" |
+    When I am logged into TRACE_X_B application
+    Then I check, if quality investigation has been received
+    Then I check, if quality investigation has proper values
+      | "description" | "Testing targetDate TRACEFOSS-1216" |
+      | "targetDate"  | "2099-03-11T22:44:06.333827Z"       |
+      | "status"      | "RECEIVED"                          |


### PR DESCRIPTION
---
name: Modify cucumber. test execution
about: 'template for PRs that ensures basic information is provided'
title: 'feat: TRACEFOSS-1220 fix duplication of test execution when new features are introduced to jira'
---

## Description

- added another test based on existing logic in cucumber test engine
- fixed situation when targetDate is not provided in investigation test execution
- adjusted pipeline to remove repository feature files before extracting jira downloaded ones to avoid execution duplication
