### PR TITLE
Fix medium security findings

### DIFF
--- a/.github/workflows/argo.yml
+++ b/.github/workflows/argo.yml
@@ -72,9 +72,18 @@ env:
     ARGO_INT_B_TRACE_X_INSTANCE: "https://argo.int.demo.catena-x.net/api/v1/applications/traceability-foss-int-b"
     ARGO_INT_B_RegistryReload: "https://traceability-int-b.int.demo.catena-x.net/api/registry/reload"
     
-jobs:      
+jobs:     
 
+  print_environment:
+   runs-on: ubuntu-latest
+   steps:
+      - name: ${{ github.event.inputs.environment }}
+        run: |
+          echo "### inputs" >> $GITHUB_STEP_SUMMARY
+          echo "- environment: ${{ github.event.inputs.environment }}" >> $GITHUB_STEP_SUMMARY
+          
   hard_refresh_environment:
+   needs: print_environment
    runs-on: ubuntu-latest
    steps:
   
@@ -87,7 +96,7 @@ jobs:
           echo ::add-mask::$ARGO_TOKEN
           echo ARGO_TOKEN=$ARGO_TOKEN >> $GITHUB_ENV
           
-      - name: Hard refresh environment
+      - name: Hard refresh environment ${{ github.event.inputs.environment }}
         run: |
          source ./.github/argo/argo_config.sh
         
@@ -103,6 +112,7 @@ jobs:
            curl -X GET -H "Authorization: Bearer ${{ env.ARGO_TOKEN }}" "$resource?refresh=hard&appNamespace=argocd"
          done
          sleep 40
+
   delete_environment:
     needs: hard_refresh_environment
     runs-on: ubuntu-latest

--- a/.github/workflows/dependencies.yaml
+++ b/.github/workflows/dependencies.yaml
@@ -38,7 +38,7 @@ jobs:
           cache: 'maven'
 
       - name: Set up Node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 18.x
 

--- a/.github/workflows/e2e-tests-xray_frontend.yml
+++ b/.github/workflows/e2e-tests-xray_frontend.yml
@@ -47,7 +47,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Use Node.js 18.x
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 18.x
 
@@ -96,12 +96,12 @@ jobs:
           path: frontend/cypress/e2e
 
       - name: Use Node.js 18.x
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 18.x
 
       - name: Cypress run all tests
-        uses: cypress-io/github-action@v6.5.0 # use the explicit version number
+        uses: cypress-io/github-action@v6.6.0 # use the explicit version number
         with:
           start: npm run start:auth:e2ea
           wait-on: "http://localhost:4200"
@@ -158,12 +158,12 @@ jobs:
  #         path: frontend/cypress/e2e
 #
  #     - name: Use Node.js 18.x
- #       uses: actions/setup-node@v3
+  #       uses: actions/setup-node@v4
  #       with:
  #         node-version: 18.x
 #
  #     - name: Cypress run all tests
- #       uses: cypress-io/github-action@v6.5.0 # use the explicit version number
+  #       uses: cypress-io/github-action@v6.6.0 # use the explicit version number
  #       with:
  #         start: npm start
  #         wait-on: "http://localhost:4200"
@@ -212,12 +212,12 @@ jobs:
 #  Error: connect ECONNREFUSED 127.0.0.1:4200"
 
 #      - name: Use Node.js 18.x
-#        uses: actions/setup-node@v3
+  #        uses: actions/setup-node@v4
 #        with:
 #          node-version: 18.x
 
  #     - name: Use Node.js 16.x
- #       uses: actions/setup-node@v3
+  #       uses: actions/setup-node@v4
  #       with:
  #         node-version: 16.x
 #
@@ -226,7 +226,7 @@ jobs:
  #       run: npx playwright install --with-deps webkit
 #
  #     - name: Cypress run all tests
- #       uses: cypress-io/github-action@v6.5.0 # use the explicit version number
+  #       uses: cypress-io/github-action@v6.6.0 # use the explicit version number
  #       with:
  #         start: npm start:auth:e2ea
  #         wait-on: "http://localhost:4200"

--- a/.github/workflows/helm-chart-release.yaml
+++ b/.github/workflows/helm-chart-release.yaml
@@ -83,7 +83,7 @@ jobs:
           helm repo add tx-item-relationship-service https://catenax-ng.github.io/tx-item-relationship-service
 
       - name: Run chart-releaser
-        uses: helm/chart-releaser-action@v1.5.0
+        uses: helm/chart-releaser-action@v1.6.0
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
           CR_RELEASE_NAME_TEMPLATE: "${{ env.RELEASE_VERSION }}"

--- a/.github/workflows/helm-test.yaml
+++ b/.github/workflows/helm-test.yaml
@@ -71,7 +71,7 @@ jobs:
           version: v3.9.3
 
       - name: Set up chart-testing
-        uses: helm/chart-testing-action@v2.4.0
+        uses: helm/chart-testing-action@v2.6.1
 
       - name: Run chart-testing (list-changed)
         id: list-changed

--- a/.github/workflows/publish-documentation.yaml
+++ b/.github/workflows/publish-documentation.yaml
@@ -48,7 +48,7 @@ jobs:
           distribution: 'temurin'
 
       - name: Setup Node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 16
 

--- a/.github/workflows/sonar-scan-frontend.yml
+++ b/.github/workflows/sonar-scan-frontend.yml
@@ -35,7 +35,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Use Node.js 18.x
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 18.x
       - name: Install chrome

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -72,7 +72,7 @@ jobs:
         run: docker build -t localhost:5000/traceability-foss:fe_${{ github.sha }} .
 
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@0.12.0
+        uses: aquasecurity/trivy-action@0.14.0
         with:
           image-ref: 'localhost:5000/traceability-foss:fe_${{ github.sha }}'
           format: "sarif"
@@ -131,7 +131,7 @@ jobs:
           ref: ${{needs.prepare-env.outputs.check_sha}}
 
       - name: Run Trivy vulnerability scanner in repo mode
-        uses: aquasecurity/trivy-action@0.12.0
+        uses: aquasecurity/trivy-action@0.14.0
         with:
           scan-type: "config"
           hide-progress: false
@@ -176,7 +176,7 @@ jobs:
           tags: localhost:5000/traceability-foss:trivy
 
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@0.12.0
+        uses: aquasecurity/trivy-action@0.14.0
         with:
           image-ref: localhost:5000/traceability-foss:trivy
           trivyignores: "./.github/workflows/.trivyignore"

--- a/.github/workflows/unit-test_frontend.yml
+++ b/.github/workflows/unit-test_frontend.yml
@@ -35,7 +35,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Use Node.js 18.x
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v4
       with:
         node-version: 18.x
     - name: Install chrome

--- a/.tractusx
+++ b/.tractusx
@@ -1,3 +1,8 @@
 product: "Traceability FOSS"
 leadingRepository: "https://github.com/eclipse-tractusx/traceability-foss"
 repositories: []
+
+# section to explicitly skip certain release guideline checks
+skipReleaseChecks:
+  alignedBaseImage:
+    - "frontend/cypress/Dockerfile"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Bump jetty-http from 11.0.15 to 11.0.17
 - Assets response have now list of notification ids rather than count of existing notifications
 - Frontend adapt to backend api changes for activeAlerts and activeInvestigations
+- Reconfigured all docker images user settings
+- Adapted memory / cpu requests and limits in default values helm file
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,14 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Reconfigured all docker images user settings
 - Adapted memory / cpu requests and limits in default values helm file
 - Migrate to not deprecated methods in HTTP security
+- Bump actions/setup-node@ from v3 to v4
+- Bump helm/chart-releaser-action from v1.5.0 to v1.6.0
+- Bump aquasecurity/trivy-action from 0.12.0 to 0.14.0
+- Bump cypress-io/github-action from v6.5.0 to v6.6.0
+- Bump spring-core version from 6.0.12 to 6.0.13
+- Bump compiler-plugin version 3.10.1 to 3.11.0
+- Bump commons-io version 2.13.0 to 2.15.0
+-
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Cypress Login to E2E Environment to enable cypress e2e tests.
 - Fixed bug in argo workflow which allows to successfully run on INT-A/INT-B
 - New job named 'print_environment' to the Argo-workflow that prints the selected environment to the GitHub Step Summary.
+- Added NOTIFICATION_COUNT_EQUAL filter strategy for Assets as built Specifications
+- Added new supported filter for notifications assetId that allows filtering alerts and investigations by assetId
 
 ### Changed
 - Fixed table-settings reset bug

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Added
 - Cypress Login to E2E Environment to enable cypress e2e tests.
 - Fixed bug in argo workflow which allows to successfully run on INT-A/INT-B
+- New job named 'print_environment' to the Argo-workflow that prints the selected environment to the GitHub Step Summary.
 
 ### Changed
 - Fixed table-settings reset bug

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,9 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Frontend adapt to backend api changes for activeAlerts and activeInvestigations
 - Reconfigured all docker images user settings
 - Adapted memory / cpu requests and limits in default values helm file
+- Fixed textarea field for dialog.
+- Removed duplicated cancel buttons from investigation and alerts workflows
+
 - Migrate to not deprecated methods in HTTP security
 - Bump actions/setup-node@ from v3 to v4
 - Bump helm/chart-releaser-action from v1.5.0 to v1.6.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Frontend adapt to backend api changes for activeAlerts and activeInvestigations
 - Reconfigured all docker images user settings
 - Adapted memory / cpu requests and limits in default values helm file
+- Migrate to not deprecated methods in HTTP security
 
 ### Removed
 

--- a/COMPATIBILITY_MATRIX.md
+++ b/COMPATIBILITY_MATRIX.md
@@ -1,0 +1,22 @@
+# Compatibility matrix v1.0
+
+## Catena-X Release?
+- [x] yes -> Catena-X Release <version>
+- [ ] no
+
+
+### (Trace-X Release)  [<version>| Release Notes](https://github.com/catenax-ng/tx-traceability-foss/releases/tag/<version>)
+
+#### Trace-X version 1.3.14
+
+| Name of service                  | Version | Comments   |
+|----------------------------------|---------|------------|
+| postgresql                       | 12.1.6  |            |
+| postgresql alias: edc-postgresql | 12.1.6  |            |
+| pgadmin4                         | 1.13.6  |            |
+| irs-helm                         | 6.8.0   |            |
+| tractusx-connector               | 0.5.0   |            |
+| discovery service                | 0.1.0   |            |
+| portal                           | ?       |            |
+| SD-Factory                       | ?       |            |
+| wallet                           | ?       |            |

--- a/DEPENDENCIES_BACKEND
+++ b/DEPENDENCIES_BACKEND
@@ -46,7 +46,7 @@ maven/mavencentral/commons-codec/commons-codec/1.15, Apache-2.0 AND BSD-3-Clause
 maven/mavencentral/commons-collections/commons-collections/3.2.2, Apache-2.0, approved, CQ10385
 maven/mavencentral/commons-digester/commons-digester/2.1, Apache-2.0, approved, clearlydefined
 maven/mavencentral/commons-fileupload/commons-fileupload/1.5, Apache-2.0, approved, #7109
-maven/mavencentral/commons-io/commons-io/2.13.0, Apache-2.0, approved, #8717
+maven/mavencentral/commons-io/commons-io/2.15.0, Apache-2.0, approved, #11244
 maven/mavencentral/commons-logging/commons-logging/1.2, Apache-2.0, approved, CQ10162
 maven/mavencentral/commons-validator/commons-validator/1.7, Apache-2.0, approved, clearlydefined
 maven/mavencentral/dev.failsafe/failsafe-okhttp/3.3.2, Apache-2.0, approved, #9178
@@ -399,11 +399,11 @@ maven/mavencentral/org.springframework/spring-aop/6.0.11, Apache-2.0, approved, 
 maven/mavencentral/org.springframework/spring-aspects/6.0.11, Apache-2.0, approved, #5930
 maven/mavencentral/org.springframework/spring-beans/6.0.11, Apache-2.0, approved, #5937
 maven/mavencentral/org.springframework/spring-context/6.0.11, Apache-2.0, approved, #5936
-maven/mavencentral/org.springframework/spring-core/6.0.12, Apache-2.0 AND BSD-3-Clause, approved, #5948
+maven/mavencentral/org.springframework/spring-core/6.0.13, Apache-2.0 AND BSD-3-Clause, approved, #5948
 maven/mavencentral/org.springframework/spring-expression/6.0.11, Apache-2.0, approved, #3284
-maven/mavencentral/org.springframework/spring-expression/6.0.12, Apache-2.0, approved, #3284
+maven/mavencentral/org.springframework/spring-expression/6.0.13, Apache-2.0, approved, #3284
 maven/mavencentral/org.springframework/spring-jcl/6.0.11, Apache-2.0, approved, #3283
-maven/mavencentral/org.springframework/spring-jcl/6.0.12, Apache-2.0, approved, #3283
+maven/mavencentral/org.springframework/spring-jcl/6.0.13, Apache-2.0, approved, #3283
 maven/mavencentral/org.springframework/spring-jdbc/6.0.11, Apache-2.0, approved, #5924
 maven/mavencentral/org.springframework/spring-jdbc/6.0.13, Apache-2.0, approved, #5924
 maven/mavencentral/org.springframework/spring-orm/6.0.11, Apache-2.0, approved, #5925

--- a/DEPENDENCIES_BACKEND
+++ b/DEPENDENCIES_BACKEND
@@ -263,9 +263,9 @@ maven/mavencentral/org.eclipse.jetty/jetty-webapp/11.0.15, EPL-2.0 OR Apache-2.0
 maven/mavencentral/org.eclipse.jetty/jetty-webapp/11.0.17, EPL-2.0 OR Apache-2.0, approved, rt.jetty
 maven/mavencentral/org.eclipse.jetty/jetty-xml/11.0.15, EPL-2.0 OR Apache-2.0, approved, rt.jetty
 maven/mavencentral/org.eclipse.jetty/jetty-xml/11.0.17, EPL-2.0 OR Apache-2.0, approved, rt.jetty
-maven/mavencentral/org.eclipse.tractusx.irs/irs-edc-client/1.4.1-20231108.130412-4, Apache-2.0, approved, automotive.tractusx
-maven/mavencentral/org.eclipse.tractusx.irs/irs-models/1.4.1-20231108.130412-4, Apache-2.0, approved, automotive.tractusx
-maven/mavencentral/org.eclipse.tractusx.irs/irs-registry-client/1.4.1-20231108.130412-4, Apache-2.0, approved, automotive.tractusx
+maven/mavencentral/org.eclipse.tractusx.irs/irs-edc-client/1.4.1-20231110.130443-8, Apache-2.0, approved, automotive.tractusx
+maven/mavencentral/org.eclipse.tractusx.irs/irs-models/1.4.1-20231110.130443-8, Apache-2.0, approved, automotive.tractusx
+maven/mavencentral/org.eclipse.tractusx.irs/irs-registry-client/1.4.1-20231110.130443-8, Apache-2.0, approved, automotive.tractusx
 maven/mavencentral/org.eclipse.tractusx.traceability/tx-backend/0.0.1-SNAPSHOT, Apache-2.0, approved, automotive.tractusx
 maven/mavencentral/org.eclipse.tractusx.traceability/tx-models/0.0.1-SNAPSHOT, Apache-2.0, approved, automotive.tractusx
 maven/mavencentral/org.flywaydb/flyway-core/9.16.3, Apache-2.0, approved, #7935

--- a/DEPENDENCIES_BACKEND
+++ b/DEPENDENCIES_BACKEND
@@ -263,9 +263,9 @@ maven/mavencentral/org.eclipse.jetty/jetty-webapp/11.0.15, EPL-2.0 OR Apache-2.0
 maven/mavencentral/org.eclipse.jetty/jetty-webapp/11.0.17, EPL-2.0 OR Apache-2.0, approved, rt.jetty
 maven/mavencentral/org.eclipse.jetty/jetty-xml/11.0.15, EPL-2.0 OR Apache-2.0, approved, rt.jetty
 maven/mavencentral/org.eclipse.jetty/jetty-xml/11.0.17, EPL-2.0 OR Apache-2.0, approved, rt.jetty
-maven/mavencentral/org.eclipse.tractusx.irs/irs-edc-client/1.4.1-20231027.142046-3, Apache-2.0, approved, automotive.tractusx
-maven/mavencentral/org.eclipse.tractusx.irs/irs-models/1.4.1-20231027.142046-3, Apache-2.0, approved, automotive.tractusx
-maven/mavencentral/org.eclipse.tractusx.irs/irs-registry-client/1.4.1-20231027.142046-3, Apache-2.0, approved, automotive.tractusx
+maven/mavencentral/org.eclipse.tractusx.irs/irs-edc-client/1.4.1-20231108.130412-4, Apache-2.0, approved, automotive.tractusx
+maven/mavencentral/org.eclipse.tractusx.irs/irs-models/1.4.1-20231108.130412-4, Apache-2.0, approved, automotive.tractusx
+maven/mavencentral/org.eclipse.tractusx.irs/irs-registry-client/1.4.1-20231108.130412-4, Apache-2.0, approved, automotive.tractusx
 maven/mavencentral/org.eclipse.tractusx.traceability/tx-backend/0.0.1-SNAPSHOT, Apache-2.0, approved, automotive.tractusx
 maven/mavencentral/org.eclipse.tractusx.traceability/tx-models/0.0.1-SNAPSHOT, Apache-2.0, approved, automotive.tractusx
 maven/mavencentral/org.flywaydb/flyway-core/9.16.3, Apache-2.0, approved, #7935

--- a/DEPENDENCIES_FRONTEND
+++ b/DEPENDENCIES_FRONTEND
@@ -1497,7 +1497,7 @@ npm/npmjs/@types/eslint/8.4.2, MIT, approved, #2429
 npm/npmjs/@types/estree/0.0.51, MIT, approved, clearlydefined
 npm/npmjs/@types/express-serve-static-core/4.17.34, MIT, approved, #6020
 npm/npmjs/@types/express/4.17.17, MIT, approved, #5760
-npm/npmjs/@types/geojson/7946.0.8, MIT, approved, clearlydefined
+npm/npmjs/@types/geojson/7946.0.8, MIT, approved, #11480
 npm/npmjs/@types/glob/7.2.0, MIT, approved, clearlydefined
 npm/npmjs/@types/http-proxy/1.17.11, MIT, approved, #8414
 npm/npmjs/@types/jasmine/4.3.1, MIT, approved, clearlydefined

--- a/charts/traceability-foss/charts/backend/values.yaml
+++ b/charts/traceability-foss/charts/backend/values.yaml
@@ -89,7 +89,7 @@ resources:
     cpu: 500m
     memory: 512Mi
   requests:
-    cpu: 500m
+    cpu: 250m
     memory: 512Mi
 
 nodeSelector: {}

--- a/charts/traceability-foss/charts/frontend/values.yaml
+++ b/charts/traceability-foss/charts/frontend/values.yaml
@@ -60,7 +60,10 @@ serviceAccount:
 
 podAnnotations: { }
 
-podSecurityContext: { }
+podSecurityContext:
+  runAsUser: 10001
+  seccompProfile:
+    type: RuntimeDefault
 # fsGroup: 2000
 
 # Following Catena-X Helm Best Practices @url: https://catenax-ng.github.io/docs/kubernetes-basics/helm
@@ -68,8 +71,12 @@ podSecurityContext: { }
 securityContext:
   allowPrivilegeEscalation: false
   runAsNonRoot: true
-  runAsUser: 101
-  # runAsGroup: 3000
+  runAsUser: 10001
+  runAsGroup: 3000
+  capabilities:
+    drop:
+      - ALL
+  readOnlyRootFilesystem: false
 
 service:
   type: ClusterIP
@@ -83,7 +90,7 @@ resources:
     cpu: 500m
     memory: 512Mi
   requests:
-    cpu: 500m
+    cpu: 250m
     memory: 512Mi
 
 nodeSelector: { }

--- a/charts/traceability-foss/charts/frontend/values.yaml
+++ b/charts/traceability-foss/charts/frontend/values.yaml
@@ -60,10 +60,7 @@ serviceAccount:
 
 podAnnotations: { }
 
-podSecurityContext:
-  runAsUser: 10001
-  seccompProfile:
-    type: RuntimeDefault
+podSecurityContext: { }
 # fsGroup: 2000
 
 # Following Catena-X Helm Best Practices @url: https://catenax-ng.github.io/docs/kubernetes-basics/helm
@@ -71,12 +68,8 @@ podSecurityContext:
 securityContext:
   allowPrivilegeEscalation: false
   runAsNonRoot: true
-  runAsUser: 10001
-  runAsGroup: 3000
-  capabilities:
-    drop:
-      - ALL
-  readOnlyRootFilesystem: false
+  runAsUser: 101
+  # runAsGroup: 3000
 
 service:
   type: ClusterIP

--- a/charts/traceability-foss/values.yaml
+++ b/charts/traceability-foss/values.yaml
@@ -78,22 +78,16 @@ frontend:
 
   podAnnotations: {}
 
-  podSecurityContext:
-    runAsUser: 10001
-    seccompProfile:
-      type: RuntimeDefault
+  podSecurityContext: {}
+  # fsGroup: 2000
 
   # Following Catena-X Helm Best Practices @url: https://catenax-ng.github.io/docs/kubernetes-basics/helm
   # @url: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
   securityContext:
     allowPrivilegeEscalation: false
     runAsNonRoot: true
-    runAsUser: 10001
-    runAsGroup: 3000
-    capabilities:
-      drop:
-        - ALL
-    readOnlyRootFilesystem: false
+    runAsUser: 101
+    # runAsGroup: 3000
 
   service:
     type: ClusterIP

--- a/charts/traceability-foss/values.yaml
+++ b/charts/traceability-foss/values.yaml
@@ -78,16 +78,22 @@ frontend:
 
   podAnnotations: {}
 
-  podSecurityContext: {}
-  # fsGroup: 2000
+  podSecurityContext:
+    runAsUser: 10001
+    seccompProfile:
+      type: RuntimeDefault
 
   # Following Catena-X Helm Best Practices @url: https://catenax-ng.github.io/docs/kubernetes-basics/helm
   # @url: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
   securityContext:
     allowPrivilegeEscalation: false
     runAsNonRoot: true
-    runAsUser: 101
-    # runAsGroup: 3000
+    runAsUser: 10001
+    runAsGroup: 3000
+    capabilities:
+      drop:
+        - ALL
+    readOnlyRootFilesystem: false
 
   service:
     type: ClusterIP
@@ -101,7 +107,7 @@ frontend:
       cpu: 500m
       memory: 512Mi
     requests:
-      cpu: 125m
+      cpu: 250m
       memory: 512Mi
 
   nodeSelector: {}
@@ -222,7 +228,7 @@ backend:
       cpu: 500m
       memory: 512Mi
     requests:
-      cpu: 125m
+      cpu: 250m
       memory: 512Mi
 
   nodeSelector: {}
@@ -324,7 +330,7 @@ pgadmin4:
   resources:
     limits:
       cpu: 1000m
-      memory: 1Gi
+      memory: 512Mi
     requests:
       cpu: 256m
       memory: 512Mi
@@ -344,6 +350,14 @@ postgresql:
     database: "trace"
     username: "traceuser"
 
+  resources:
+    limits:
+      cpu: 500m
+      memory: 512Mi
+    requests:
+      cpu: 250m
+      memory: 512Mi
+
 #########################
 # IRS configuration     #
 #########################
@@ -351,6 +365,14 @@ irs-helm:
   enabled: false  # <irs-helm.enabled>
   nameOverride: "tracex-irs"
   fullnameOverride: "tracex-irs"
+
+  resources:
+    limits:
+      cpu: 500m
+      memory: 512Mi
+    requests:
+      cpu: 250m
+      memory: 512Mi
 ###################################
 # EDC Consumer configuration  #
 ###################################
@@ -360,6 +382,14 @@ tractusx-connector:
   fullnameOverride: "tracex-consumer-edc"
   participant:
     id: "BPN"
+
+  resources:
+    limits:
+      cpu: 500m
+      memory: 512Mi
+    requests:
+      cpu: 250m
+      memory: 512Mi
 
   ##################################
   # EDC Postgres Configuration #
@@ -385,3 +415,11 @@ edc-postgresql:
     password: "CHANGEME"
     database: "trace"
     username: "traceuser"
+
+  resources:
+    limits:
+      cpu: 500m
+      memory: 512Mi
+    requests:
+      cpu: 250m
+      memory: 512Mi

--- a/docs/src/docs/arc42/solution-strategy/structure.adoc
+++ b/docs/src/docs/arc42/solution-strategy/structure.adoc
@@ -3,10 +3,11 @@
 Trace-X is divided into two components: Frontend and Backend.
 It roughly can be broken down into the following parts:
 
-* Asset controller to get the asset information
+* Asset controllers to get the asset information
 * Dashboard controller to get dashboard related summed up information
 * Registry controller to fetch assets from the Digital Twin Registry
-* Registry lookup metrics controller to set parameters to the Registry lookup
+* Notification controllers to get notification information
+* Submodel controller for providing asset data functionality
 
-The backend does a request to the Digital Twin Registry utilizing the Registry controller and Registry lookup metrics. Extracted data from the response is made available through the Asset controller and the Dashboard controller to the Frontend.
+The backend does a request to the Digital Twin Registry utilizing the Registry controller. Extracted data from the response is made available through the Asset controller and the Dashboard controller to the Frontend.
 

--- a/docs/src/docs/user/user-manual.adoc
+++ b/docs/src/docs/user/user-manual.adoc
@@ -1,6 +1,6 @@
 = Users Manual
 
-## Notice
+== Notice
 
 This work is licensed under the [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0).
 
@@ -23,17 +23,17 @@ A list of user or technical roles can be found below:
 
 Available roles: https://portal.int.demo.catena-x.net/appusermanagement/3bbc88ae-5f0d-45cb-ab3e-8c7602ff58b4
 
-image::https://raw.githubusercontent.com/eclipse-tractusx/traceability-foss/main/docs/src/images/usermanual/app_roles.png[]
+image::https://raw.githubusercontent.com/eclipse-tractusx/traceability-foss/main/docs/src/images/user-manual/app_roles.png[]
 
 Assignment of roles: https://portal.int.demo.catena-x.net/documentation/?path=docs%2F03.+User+Management%2F02.+Modify+User+Account%2F03.+User+Permissions.md
 
-image::https://raw.githubusercontent.com/eclipse-tractusx/traceability-foss/main/docs/src/images/usermanual/assign_app_roles.png[]
+image::https://raw.githubusercontent.com/eclipse-tractusx/traceability-foss/main/docs/src/images/user-manual/assign_app_roles.png[]
 
 === Catena-X portal roles
 
 Role details: https://portal.int.demo.catena-x.net/role-details
 
-image::https://raw.githubusercontent.com/eclipse-tractusx/traceability-foss/main/docs/src/images/usermanual/cx_portal_roles.png[]
+image::https://raw.githubusercontent.com/eclipse-tractusx/traceability-foss/main/docs/src/images/user-manual/cx_portal_roles.png[]
 
 User accounts: https://portal.int.demo.catena-x.net/documentation/?path=docs%2F03.+User+Management%2F01.+User+Account
 

--- a/frontend/cypress/Dockerfile
+++ b/frontend/cypress/Dockerfile
@@ -28,14 +28,18 @@
 # "Command was killed with SIGTRAP (Debugger breakpoint):..."
 # but cypress/included:12.3.0 version base on cypress/browsers:node16.16.0-chrome107-ff107-edge
 FROM cypress/included:12.3.0
+# Create a new non-root user
+RUN groupadd -r cypressuser && useradd -r -g cypressuser cypressuser
+USER cypressuser
 
-USER root
 RUN mkdir /ng-app
 WORKDIR /ng-app
 
 # Copy dependencies info
 COPY package.json  /ng-app/package.json
 COPY yarn.lock /ng-app/yarn.lock
+
+RUN chown -R cypressuser:cypressuser /ng-app
 
 RUN yarn install
 # https://docs.cypress.io/guides/guides/launching-browsers#Linux-Dependencies

--- a/frontend/src/app/modules/page/other-parts/core/other-parts.service.ts
+++ b/frontend/src/app/modules/page/other-parts/core/other-parts.service.ts
@@ -33,6 +33,7 @@ import { enrichFilterAndGetUpdatedParams } from '@shared/helper/filter-helper';
 import { Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
 
+// TODO: merge this service with parts-service. The difference here should only be the owner parameter. (Own Parts = OWNER=OWN, supplier = OWNER=SUPPLIER, customer = OWNER=CUSTOMER
 @Injectable()
 export class OtherPartsService {
   private url = environment.apiUrl;

--- a/frontend/src/app/modules/page/parts/model/parts.model.ts
+++ b/frontend/src/app/modules/page/parts/model/parts.model.ts
@@ -170,7 +170,8 @@ export enum FilterOperator {
   AT_LOCAL_DATE = 'AT_LOCAL_DATE',
   STARTS_WITH = 'STARTS_WITH',
   BEFORE_LOCAL_DATE = 'BEFORE_LOCAL_DATE',
-  AFTER_LOCAL_DATE = 'AFTER_LOCAL_DATE'
+  AFTER_LOCAL_DATE = 'AFTER_LOCAL_DATE',
+  NOTIFICATION_COUNT_EQUAL = 'NOTIFICATION_COUNT_EQUAL'
 }
 
 export function getFilterOperatorValue(operator: FilterOperator) {

--- a/frontend/src/app/modules/shared/assembler/parts.assembler.ts
+++ b/frontend/src/app/modules/shared/assembler/parts.assembler.ts
@@ -98,7 +98,7 @@ export class PartsAssembler {
       partId: partId, // is partInstance, BatchId, jisNumber
       customerPartId: customerPartId,
       nameAtCustomer: nameAtCustomer,
-      manufacturingDate: manufacturingDate,
+      manufacturingDate: manufacturingDate === "null" ? null : manufacturingDate ,
       manufacturingCountry: manufacturingCountry,
 
       // tractionBatteryCode
@@ -107,14 +107,14 @@ export class PartsAssembler {
       subcomponents: subcomponents,
 
       // as planned
-      validityPeriodFrom: validityPeriodFrom,
-      validityPeriodTo: validityPeriodTo,
+      validityPeriodFrom: validityPeriodFrom === "null" ? null : validityPeriodFrom,
+      validityPeriodTo: validityPeriodTo === "null" ? null :  validityPeriodTo,
 
       //partSiteInformationAsPlanned
       catenaXSiteId: catenaXSiteId,
       psFunction: psFunction,
-      functionValidFrom: functionValidFrom,
-      functionValidUntil: functionValidUntil,
+      functionValidFrom:  functionValidFrom=== "null" ? null :  functionValidFrom,
+      functionValidUntil: functionValidUntil=== "null" ? null :   functionValidUntil,
 
       // count of notifications
       activeAlerts: partResponse.qualityAlertIdsInStatusActive,

--- a/frontend/src/app/modules/shared/components/parts-table/parts-table.component.ts
+++ b/frontend/src/app/modules/shared/components/parts-table/parts-table.component.ts
@@ -752,10 +752,6 @@ export class PartsTableComponent implements OnInit {
         this.multiSelect.emit(this.selection.selected);
     }
 
-    public toggleFilter(): void {
-        this.displayedFilter = !this.displayedFilter;
-    }
-
     public isSelected(row: unknown): boolean {
         return !!this.selection.selected.find(data => JSON.stringify(data) === JSON.stringify(row));
     }

--- a/frontend/src/app/modules/shared/components/textarea/textarea.component.html
+++ b/frontend/src/app/modules/shared/components/textarea/textarea.component.html
@@ -27,11 +27,9 @@ SPDX-License-Identifier: Apache-2.0
       [formControl]="control"
       [attr.data-testId]="htmlId"
       [errorStateMatcher]="matcher"
+      style="line-height: 1.5;"
       matInput
-      cdkTextareaAutosize
-      #autosize="cdkTextareaAutosize"
-      cdkAutosizeMinRows="1"
-      cdkAutosizeMaxRows="5"
+
     ></textarea>
     <mat-icon *ngIf="matcher.isErrorState(control)" color="warn" matSuffix>error_outline</mat-icon>
     <mat-hint *ngIf="hint" align="start">{{ hint }}</mat-hint>

--- a/frontend/src/app/modules/shared/components/textarea/textarea.component.scss
+++ b/frontend/src/app/modules/shared/components/textarea/textarea.component.scss
@@ -23,7 +23,9 @@
   display: flex;
   flex-direction: column;
   textarea{
-    min-height:100px;
+    min-height:280px;
+    max-height:450px;
+    margin-top:7px;
   }
 
 }

--- a/frontend/src/app/modules/shared/components/textarea/textarea.component.scss
+++ b/frontend/src/app/modules/shared/components/textarea/textarea.component.scss
@@ -22,4 +22,9 @@
 .textarea--container {
   display: flex;
   flex-direction: column;
+  textarea{
+    min-height:100px;
+  }
+
 }
+

--- a/frontend/src/app/modules/shared/helper/filter-helper.ts
+++ b/frontend/src/app/modules/shared/helper/filter-helper.ts
@@ -24,56 +24,70 @@ import {
   getFilterOperatorValue,
 } from '@page/parts/model/parts.model';
 
-export const FILTER_KEYS = ['manufacturingDate', 'functionValidFrom', 'functionValidUntil', 'validityPeriodFrom', 'validityPeriodTo'];
+export const DATE_FILTER_KEYS = [ 'manufacturingDate', 'functionValidFrom', 'functionValidUntil', 'validityPeriodFrom', 'validityPeriodTo' ];
+
 // TODO: Refactor function as soon as multi value filter is supported
 export function enrichFilterAndGetUpdatedParams(filter: AssetAsBuiltFilter, params: HttpParams, filterOperator: string): HttpParams {
-    const semanticDataModelKey = "semanticDataModel";
-    for (const key in filter) {
-        let operator: string;
-        const filterValues: string = filter[key];
-        if (key !== semanticDataModelKey) {
-            if (filterValues.length !== 0) {
-                if (isDateFilter(key)) {
-                  if(isDateRangeFilter(filterValues)) {
-                    const [startDate, endDate] = filterValues.split(",")
-                    if(isSameDate(startDate,endDate)) {
-                      operator = getFilterOperatorValue(FilterOperator.AT_LOCAL_DATE);
-                      params = params.append('filter', `${key},${operator},${startDate},${filterOperator}`);
-                      continue;
-                    }
-                    let endDateOperator = getFilterOperatorValue(FilterOperator.BEFORE_LOCAL_DATE)
-                    operator = getFilterOperatorValue((FilterOperator.AFTER_LOCAL_DATE));
-                    params = params.append('filter', `${key},${operator},${startDate},${filterOperator}`);
-                    params = params.append('filter', `${key},${endDateOperator},${endDate},${filterOperator}`);
-                    continue;
-                  } else {
-                    operator = getFilterOperatorValue(FilterOperator.AFTER_LOCAL_DATE);
-                  }
-                } else {
-                    operator = getFilterOperatorValue(FilterOperator.STARTS_WITH);
-                }
-                params = params.append('filter', `${key},${operator},${filterValues},${filterOperator}`);
+  const semanticDataModelKey = 'semanticDataModel';
+  for (const key in filter) {
+    let operator: string;
+    const filterValues: string = filter[key];
+    if (key !== semanticDataModelKey) {
+      if (filterValues.length !== 0) {
+        if (isDateFilter(key)) {
+          if (isDateRangeFilter(filterValues)) {
+            const [ startDate, endDate ] = filterValues.split(',');
+            if (isSameDate(startDate, endDate)) {
+              operator = getFilterOperatorValue(FilterOperator.AT_LOCAL_DATE);
+              params = params.append('filter', `${ key },${ operator },${ startDate },${ filterOperator }`);
+              continue;
             }
+            let endDateOperator = getFilterOperatorValue(FilterOperator.BEFORE_LOCAL_DATE);
+            operator = getFilterOperatorValue((FilterOperator.AFTER_LOCAL_DATE));
+            params = params.append('filter', `${ key },${ operator },${ startDate },${ filterOperator }`);
+            params = params.append('filter', `${ key },${ endDateOperator },${ endDate },${ filterOperator }`);
+            continue;
+          } else {
+            operator = getFilterOperatorValue(FilterOperator.AFTER_LOCAL_DATE);
+          }
         } else {
-            operator = getFilterOperatorValue(FilterOperator.EQUAL);
-            if (Array.isArray(filterValues)) {
-                for (let value of filterValues) {
-                    params = params.append('filter', `${key},${operator},${value},${filterOperator}`);
-                }
-            } else {
-                params = params.append('filter', `${key},${operator},${filterValues},${filterOperator}`);
-            }
+          if (isNotificationCountFilter(key)) {
+            operator = getFilterOperatorValue(FilterOperator.NOTIFICATION_COUNT_EQUAL);
+          } else {
+            operator = getFilterOperatorValue(FilterOperator.STARTS_WITH);
+          }
+
         }
+        params = params.append('filter', `${ key },${ operator },${ filterValues },${ filterOperator }`);
+      }
+    } else {
+      operator = getFilterOperatorValue(FilterOperator.EQUAL);
+      if (Array.isArray(filterValues)) {
+        for (let value of filterValues) {
+          params = params.append('filter', `${ key },${ operator },${ value },${ filterOperator }`);
+        }
+      } else {
+        params = params.append('filter', `${ key },${ operator },${ filterValues },${ filterOperator }`);
+      }
     }
-    return params;
+  }
+  return params;
+}
+
+export function isStartsWithFilter(key: string): boolean {
+  return !isDateFilter(key) && !isNotificationCountFilter(key);
+}
+
+export function isNotificationCountFilter(key: string): boolean {
+  return 'qualityInvestigationIdsInStatusActive' === key || 'qualityAlertIdsInStatusActive' === key;
 }
 
 export function isDateFilter(key: string): boolean {
-    return FILTER_KEYS.includes(key);
+  return DATE_FILTER_KEYS.includes(key);
 }
 
 export function isDateRangeFilter(filterValues: string): boolean {
-  return filterValues.includes(",");
+  return filterValues.includes(',');
 }
 
 export function isSameDate(startDate: string, endDate: string): boolean {
@@ -82,46 +96,54 @@ export function isSameDate(startDate: string, endDate: string): boolean {
 
 export function toAssetFilter(formValues: any, isAsBuilt: boolean): AssetAsPlannedFilter | AssetAsBuiltFilter {
 
-    const transformedFilter: any = {};
+  const transformedFilter: any = {};
 
-    // Loop through each form control and add it to the transformedFilter if it has a non-null and non-undefined value
-    for (const key in formValues) {
-        if (formValues[key] !== null && formValues[key] !== undefined) {
-            transformedFilter[key] = formValues[key];
-        }
+  // Loop through each form control and add it to the transformedFilter if it has a non-null and non-undefined value
+  for (const key in formValues) {
+    if (formValues[key] !== null && formValues[key] !== undefined) {
+      if ('activeAlerts' === key) {
+        transformedFilter['qualityAlertIdsInStatusActive'] = formValues[key];
+      }
+      if ('activeInvestigations' === key) {
+        transformedFilter['qualityInvestigationIdsInStatusActive'] = formValues[key];
+      } else {
+        transformedFilter[key] = formValues[key];
+      }
+
     }
+  }
 
-    const filterIsSet = Object.values(transformedFilter).some(value => value !== undefined && value !== null);
-    if (filterIsSet) {
-        if (isAsBuilt) {
-            return transformedFilter as AssetAsBuiltFilter;
-        } else {
-            return transformedFilter as AssetAsPlannedFilter;
-        }
+  const filterIsSet = Object.values(transformedFilter).some(value => value !== undefined && value !== null);
+  if (filterIsSet) {
+    if (isAsBuilt) {
+      return transformedFilter as AssetAsBuiltFilter;
     } else {
-        return null;
+      return transformedFilter as AssetAsPlannedFilter;
     }
+  } else {
+    return null;
+  }
 
 }
 
 export function toGlobalSearchAssetFilter(formValues: string, isAsBuilt: boolean) {
-    let filter;
-    if (isAsBuilt) {
-        filter = {
-            id: formValues,
-            semanticModelId: formValues,
-            idShort: formValues,
-            customerPartId: formValues,
-            manufacturerPartId: formValues
-        } as AssetAsBuiltFilter;
-    } else {
-        filter = {
-            id: formValues,
-            idShort: formValues,
-            semanticModelId: formValues,
-            manufacturerPartId: formValues
-        } as AssetAsPlannedFilter;
-    }
+  let filter;
+  if (isAsBuilt) {
+    filter = {
+      id: formValues,
+      semanticModelId: formValues,
+      idShort: formValues,
+      customerPartId: formValues,
+      manufacturerPartId: formValues,
+    } as AssetAsBuiltFilter;
+  } else {
+    filter = {
+      id: formValues,
+      idShort: formValues,
+      semanticModelId: formValues,
+      manufacturerPartId: formValues,
+    } as AssetAsPlannedFilter;
+  }
 
-    return filter;
+  return filter;
 }

--- a/frontend/src/app/modules/shared/helper/filter-helper.ts
+++ b/frontend/src/app/modules/shared/helper/filter-helper.ts
@@ -71,6 +71,7 @@ export function enrichFilterAndGetUpdatedParams(filter: AssetAsBuiltFilter, para
       }
     }
   }
+  console.log(params.toString(), 'params');
   return params;
 }
 
@@ -103,12 +104,13 @@ export function toAssetFilter(formValues: any, isAsBuilt: boolean): AssetAsPlann
     if (formValues[key] !== null && formValues[key] !== undefined) {
       if ('activeAlerts' === key) {
         transformedFilter['qualityAlertIdsInStatusActive'] = formValues[key];
+        continue;
       }
       if ('activeInvestigations' === key) {
         transformedFilter['qualityInvestigationIdsInStatusActive'] = formValues[key];
-      } else {
-        transformedFilter[key] = formValues[key];
+        continue;
       }
+      transformedFilter[key] = formValues[key];
 
     }
   }

--- a/frontend/src/app/modules/shared/modules/modal/component/modal.component.html
+++ b/frontend/src/app/modules/shared/modules/modal/component/modal.component.html
@@ -31,7 +31,7 @@ SPDX-License-Identifier: Apache-2.0
 
   <mat-dialog-actions>
     <app-button *ngIf="data.buttonLeft" (click)="cancel()" variant="raised">{{ data.buttonLeft | i18n }}</app-button>
-    <app-button
+    <app-button [ngClass]="data.buttonLeft ? '' : 'centered-button'"
       *ngIf="data.buttonRight"
       (click)="confirm()"
       [color]="data.primaryButtonColour || 'primary'"

--- a/frontend/src/app/modules/shared/modules/modal/component/modal.component.scss
+++ b/frontend/src/app/modules/shared/modules/modal/component/modal.component.scss
@@ -29,3 +29,9 @@
     margin: unset !important;
   }
 }
+
+.centered-button{
+  display: flex;
+  justify-content: center;
+  width: 100%;
+}

--- a/frontend/src/app/modules/shared/modules/modal/core/modal.model.ts
+++ b/frontend/src/app/modules/shared/modules/modal/core/modal.model.ts
@@ -24,7 +24,7 @@ import { UntypedFormGroup } from '@angular/forms';
 
 export interface ModalData {
   title: string;
-  buttonLeft: string;
+  buttonLeft?: string;
   buttonRight: string;
   primaryButtonColour?: 'primary' | 'accent' | 'warn';
 

--- a/frontend/src/app/modules/shared/modules/notification/modal/accept/accept-notification-modal.component.spec.ts
+++ b/frontend/src/app/modules/shared/modules/notification/modal/accept/accept-notification-modal.component.spec.ts
@@ -30,12 +30,10 @@ describe('AcceptNotificationModalComponent', () => {
     await renderAcceptModal(NotificationStatus.ACKNOWLEDGED);
     const title = await waitFor(() => screen.getByText('commonInvestigation.modal.acceptTitle'));
     const hint2 = await waitFor(() => screen.getByText('commonInvestigation.modal.acceptReasonHint'));
-    const buttonL = await waitFor(() => screen.getByText('actions.cancel'));
     const buttonR = await waitFor(() => screen.getByText('actions.accept'));
 
     expect(title).toBeInTheDocument();
     expect(hint2).toBeInTheDocument();
-    expect(buttonL).toBeInTheDocument();
     expect(buttonR).toBeInTheDocument();
   });
 

--- a/frontend/src/app/modules/shared/modules/notification/modal/accept/accept-notification-modal.component.ts
+++ b/frontend/src/app/modules/shared/modules/notification/modal/accept/accept-notification-modal.component.ts
@@ -72,8 +72,6 @@ export class AcceptNotificationModalComponent {
     const options: ModalData = {
       title: this.translationContext + '.modal.acceptTitle',
       buttonRight: 'actions.accept',
-      buttonLeft: 'actions.cancel',
-
       template: this.modal,
       formGroup: this.formGroup,
       onConfirm,

--- a/frontend/src/app/modules/shared/modules/notification/modal/acknowledge/acknowledge-notification-modal.component.spec.ts
+++ b/frontend/src/app/modules/shared/modules/notification/modal/acknowledge/acknowledge-notification-modal.component.spec.ts
@@ -28,11 +28,9 @@ describe('AcknowledgeNotificationModalComponent', () => {
   it('should create acknowledge modal', async () => {
     await renderAcknowledgeModal(NotificationStatus.RECEIVED);
     const title = await waitFor(() => screen.getByText('commonInvestigation.modal.acknowledgeTitle'));
-    const buttonL = await waitFor(() => screen.getByText('actions.cancel'));
     const buttonR = await waitFor(() => screen.getByText('actions.acknowledge'));
 
     expect(title).toBeInTheDocument();
-    expect(buttonL).toBeInTheDocument();
     expect(buttonR).toBeInTheDocument();
   });
 

--- a/frontend/src/app/modules/shared/modules/notification/modal/acknowledge/acknowledge-notification-modal.component.ts
+++ b/frontend/src/app/modules/shared/modules/notification/modal/acknowledge/acknowledge-notification-modal.component.ts
@@ -60,7 +60,6 @@ export class AcknowledgeNotificationModalComponent {
     const options: ModalData = {
       title: this.translationContext + '.modal.acknowledgeTitle',
       buttonRight: 'actions.acknowledge',
-      buttonLeft: 'actions.cancel',
 
       template: this.modal,
       onConfirm,

--- a/frontend/src/app/modules/shared/modules/notification/modal/cancel/cancel-notification-modal.component.html
+++ b/frontend/src/app/modules/shared/modules/notification/modal/cancel/cancel-notification-modal.component.html
@@ -24,6 +24,6 @@ SPDX-License-Identifier: Apache-2.0
 
   <form [formGroup]="formGroup" class="mt-4">
     <mat-hint>{{ translationContext + '.modal.cancellationHint' | i18n }}</mat-hint>
-    <app-textarea formControlName="notificationId" [label]="notification?.id"></app-textarea>
+    <app-input formControlName="notificationId" [label]="notification?.id"></app-input>
   </form>
 </ng-template>

--- a/frontend/src/app/modules/shared/modules/notification/modal/cancel/cancel-notification-modal.component.spec.ts
+++ b/frontend/src/app/modules/shared/modules/notification/modal/cancel/cancel-notification-modal.component.spec.ts
@@ -29,12 +29,10 @@ describe('CancelNotificationModalComponent', () => {
     await renderCancelModal(NotificationStatus.CREATED);
     const title = await waitFor(() => screen.getByText('commonInvestigation.modal.cancellationTitle'));
     const hint2 = await waitFor(() => screen.getByText('commonInvestigation.modal.cancellationHint'));
-    const buttonL = await waitFor(() => screen.getByText('actions.cancel'));
     const buttonR = await waitFor(() => screen.getByText('actions.cancellationConfirm'));
 
     expect(title).toBeInTheDocument();
     expect(hint2).toBeInTheDocument();
-    expect(buttonL).toBeInTheDocument();
     expect(buttonR).toBeInTheDocument();
   });
 

--- a/frontend/src/app/modules/shared/modules/notification/modal/cancel/cancel-notification-modal.component.ts
+++ b/frontend/src/app/modules/shared/modules/notification/modal/cancel/cancel-notification-modal.component.ts
@@ -67,7 +67,6 @@ export class CancelNotificationModalComponent {
     const options: ModalData = {
       title: this.translationContext + '.modal.cancellationTitle',
       buttonRight: 'actions.cancellationConfirm',
-      buttonLeft: 'actions.cancel',
       primaryButtonColour: 'warn',
 
       template: this.modal,

--- a/frontend/src/app/modules/shared/modules/notification/modal/close/close-notification-modal.component.spec.ts
+++ b/frontend/src/app/modules/shared/modules/notification/modal/close/close-notification-modal.component.spec.ts
@@ -30,12 +30,10 @@ describe('CloseNotificationModalComponent', () => {
     await renderCloseModal(NotificationStatus.SENT);
     const title = await waitFor(() => screen.getByText('commonInvestigation.modal.closeTitle'));
     const hint2 = await waitFor(() => screen.getByText('commonInvestigation.modal.closeReasonHint'));
-    const buttonL = await waitFor(() => screen.getByText('actions.cancel'));
     const buttonR = await waitFor(() => screen.getByText('actions.close'));
 
     expect(title).toBeInTheDocument();
     expect(hint2).toBeInTheDocument();
-    expect(buttonL).toBeInTheDocument();
     expect(buttonR).toBeInTheDocument();
   });
 

--- a/frontend/src/app/modules/shared/modules/notification/modal/close/close-notification-modal.component.ts
+++ b/frontend/src/app/modules/shared/modules/notification/modal/close/close-notification-modal.component.ts
@@ -70,7 +70,6 @@ export class CloseNotificationModalComponent {
     const options: ModalData = {
       title: this.translationContext + '.modal.closeTitle',
       buttonRight: 'actions.close',
-      buttonLeft: 'actions.cancel',
 
       template: this.modal,
       formGroup: this.formGroup,

--- a/frontend/src/app/modules/shared/modules/notification/modal/decline/decline-notification-modal.component.spec.ts
+++ b/frontend/src/app/modules/shared/modules/notification/modal/decline/decline-notification-modal.component.spec.ts
@@ -29,12 +29,10 @@ describe('DeclineNotificationModalComponent', () => {
     await renderDeclineModal(NotificationStatus.ACKNOWLEDGED);
     const title = await waitFor(() => screen.getByText('commonInvestigation.modal.declineTitle'));
     const hint2 = await waitFor(() => screen.getByText('commonInvestigation.modal.declineReasonHint'));
-    const buttonL = await waitFor(() => screen.getByText('actions.cancel'));
     const buttonR = await waitFor(() => screen.getByText('actions.decline'));
 
     expect(title).toBeInTheDocument();
     expect(hint2).toBeInTheDocument();
-    expect(buttonL).toBeInTheDocument();
     expect(buttonR).toBeInTheDocument();
   });
 

--- a/frontend/src/app/modules/shared/modules/notification/modal/decline/decline-notification-modal.component.ts
+++ b/frontend/src/app/modules/shared/modules/notification/modal/decline/decline-notification-modal.component.ts
@@ -70,7 +70,6 @@ export class DeclineNotificationModalComponent {
     const options: ModalData = {
       title: this.translationContext + '.modal.declineTitle',
       buttonRight: 'actions.decline',
-      buttonLeft: 'actions.cancel',
 
       template: this.modal,
       formGroup: this.formGroup,

--- a/frontend/src/theme/base.scss
+++ b/frontend/src/theme/base.scss
@@ -153,7 +153,6 @@
 }
 
 
-
 as-split-area {
   box-shadow: 0 2px 2px -3px rgba(0, 0, 0, 0.2), 0px 4px 6px -1px rgba(0, 0, 0, 0.14), 0px 1px 8px -2px rgba(0, 0, 0, 0.12);
   border-radius: 20px;
@@ -246,4 +245,11 @@ app-parts, app-other-parts, app-notifications-tab {
 
   }
 
+}
+
+/* Apply correct padding for text value inside of textarea*/
+app-textarea {
+  .mat-mdc-form-field-infix {
+    padding-top: 14px !important;
+  }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@ SPDX-License-Identifier: Apache-2.0
 
     <properties>
         <springboot.version>3.1.3</springboot.version>
-        <spring-core.version>6.0.12</spring-core.version>
+        <spring-core.version>6.0.13</spring-core.version>
         <spring-security-config.version>6.1.3</spring-security-config.version>
         <java.version>17</java.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>
@@ -50,7 +50,7 @@ SPDX-License-Identifier: Apache-2.0
         <!-- versions for Maven plugin -->
         <ascii-doctor.maven.plugin.version>2.2.4</ascii-doctor.maven.plugin.version>
         <checkstyle-plugin.version>3.3.0</checkstyle-plugin.version>
-        <compiler-plugin.version>3.10.1</compiler-plugin.version>
+        <compiler-plugin.version>3.11.0</compiler-plugin.version>
         <findsecbugs-plugin.version>1.12.0</findsecbugs-plugin.version>
         <install-plugin.version>3.0.1</install-plugin.version>
         <jacoco-plugin.version>0.8.8</jacoco-plugin.version>
@@ -83,7 +83,7 @@ SPDX-License-Identifier: Apache-2.0
         <findbugs-jsr305.version>3.0.2</findbugs-jsr305.version>
         <swagger-annotation.version>1.6.12</swagger-annotation.version>
         <jackson-databind-nullable.version>0.2.6</jackson-databind-nullable.version>
-        <commons-io.version>2.13.0</commons-io.version>
+        <commons-io.version>2.15.0</commons-io.version>
         <jose4j.version>0.9.3</jose4j.version>
         <restito.version>1.1.0</restito.version>
         <testcontainer-postgresql.version>1.19.1</testcontainer-postgresql.version>

--- a/tx-backend/openapi/traceability-foss-backend.json
+++ b/tx-backend/openapi/traceability-foss-backend.json
@@ -41,16 +41,6 @@
         "description" : "The endpoint returns a result of BPN EDC URL mappings.",
         "operationId" : "getBpnEdcs",
         "responses" : {
-          "429" : {
-            "description" : "Too many requests.",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
           "200" : {
             "description" : "Returns the paged result found",
             "content" : {
@@ -63,28 +53,18 @@
               }
             }
           },
+          "415" : {
+            "description" : "Unsupported media type",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
           "500" : {
             "description" : "Internal server error.",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "404" : {
-            "description" : "Not found.",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "401" : {
-            "description" : "Authorization failed.",
             "content" : {
               "application/json" : {
                 "schema" : {
@@ -103,8 +83,8 @@
               }
             }
           },
-          "415" : {
-            "description" : "Unsupported media type",
+          "401" : {
+            "description" : "Authorization failed.",
             "content" : {
               "application/json" : {
                 "schema" : {
@@ -115,6 +95,26 @@
           },
           "400" : {
             "description" : "Bad request.",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404" : {
+            "description" : "Not found.",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "429" : {
+            "description" : "Too many requests.",
             "content" : {
               "application/json" : {
                 "schema" : {
@@ -155,20 +155,8 @@
           "required" : true
         },
         "responses" : {
-          "200" : {
-            "description" : "Returns the paged result found for BpnEdcMapping",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "maxItems" : 2147483647,
-                  "minItems" : 0,
-                  "type" : "array"
-                }
-              }
-            }
-          },
-          "429" : {
-            "description" : "Too many requests.",
+          "415" : {
+            "description" : "Unsupported media type",
             "content" : {
               "application/json" : {
                 "schema" : {
@@ -187,8 +175,20 @@
               }
             }
           },
-          "404" : {
-            "description" : "Not found.",
+          "200" : {
+            "description" : "Returns the paged result found for BpnEdcMapping",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "maxItems" : 2147483647,
+                  "minItems" : 0,
+                  "type" : "array"
+                }
+              }
+            }
+          },
+          "403" : {
+            "description" : "Forbidden.",
             "content" : {
               "application/json" : {
                 "schema" : {
@@ -207,28 +207,28 @@
               }
             }
           },
-          "403" : {
-            "description" : "Forbidden.",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "415" : {
-            "description" : "Unsupported media type",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
           "400" : {
             "description" : "Bad request.",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404" : {
+            "description" : "Not found.",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "429" : {
+            "description" : "Too many requests.",
             "content" : {
               "application/json" : {
                 "schema" : {
@@ -269,20 +269,8 @@
           "required" : true
         },
         "responses" : {
-          "200" : {
-            "description" : "Returns the paged result found for BpnEdcMapping",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "maxItems" : 2147483647,
-                  "minItems" : 0,
-                  "type" : "array"
-                }
-              }
-            }
-          },
-          "429" : {
-            "description" : "Too many requests.",
+          "415" : {
+            "description" : "Unsupported media type",
             "content" : {
               "application/json" : {
                 "schema" : {
@@ -301,8 +289,20 @@
               }
             }
           },
-          "404" : {
-            "description" : "Not found.",
+          "200" : {
+            "description" : "Returns the paged result found for BpnEdcMapping",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "maxItems" : 2147483647,
+                  "minItems" : 0,
+                  "type" : "array"
+                }
+              }
+            }
+          },
+          "403" : {
+            "description" : "Forbidden.",
             "content" : {
               "application/json" : {
                 "schema" : {
@@ -321,28 +321,28 @@
               }
             }
           },
-          "403" : {
-            "description" : "Forbidden.",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "415" : {
-            "description" : "Unsupported media type",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
           "400" : {
             "description" : "Bad request.",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404" : {
+            "description" : "Not found.",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "429" : {
+            "description" : "Too many requests.",
             "content" : {
               "application/json" : {
                 "schema" : {
@@ -380,14 +380,8 @@
           }
         ],
         "responses" : {
-          "200" : {
-            "description" : "Returns the paged result found",
-            "content" : {
-              "application/json" : {}
-            }
-          },
-          "429" : {
-            "description" : "Too many requests.",
+          "415" : {
+            "description" : "Unsupported media type",
             "content" : {
               "application/json" : {
                 "schema" : {
@@ -406,8 +400,14 @@
               }
             }
           },
-          "404" : {
-            "description" : "Not found.",
+          "200" : {
+            "description" : "Returns the paged result found",
+            "content" : {
+              "application/json" : {}
+            }
+          },
+          "403" : {
+            "description" : "Forbidden.",
             "content" : {
               "application/json" : {
                 "schema" : {
@@ -426,28 +426,28 @@
               }
             }
           },
-          "403" : {
-            "description" : "Forbidden.",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "415" : {
-            "description" : "Unsupported media type",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
           "400" : {
             "description" : "Bad request.",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404" : {
+            "description" : "Not found.",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "429" : {
+            "description" : "Too many requests.",
             "content" : {
               "application/json" : {
                 "schema" : {
@@ -493,8 +493,8 @@
           "required" : true
         },
         "responses" : {
-          "429" : {
-            "description" : "Too many requests.",
+          "415" : {
+            "description" : "Unsupported media type",
             "content" : {
               "application/json" : {
                 "schema" : {
@@ -513,29 +513,6 @@
               }
             }
           },
-          "404" : {
-            "description" : "Not found.",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "204" : {
-            "description" : "No Content."
-          },
-          "401" : {
-            "description" : "Authorization failed.",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
           "403" : {
             "description" : "Forbidden.",
             "content" : {
@@ -546,8 +523,8 @@
               }
             }
           },
-          "415" : {
-            "description" : "Unsupported media type",
+          "401" : {
+            "description" : "Authorization failed.",
             "content" : {
               "application/json" : {
                 "schema" : {
@@ -565,6 +542,29 @@
                 }
               }
             }
+          },
+          "404" : {
+            "description" : "Not found.",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "429" : {
+            "description" : "Too many requests.",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "204" : {
+            "description" : "No Content."
           }
         },
         "security" : [
@@ -603,8 +603,8 @@
           }
         ],
         "responses" : {
-          "429" : {
-            "description" : "Too many requests.",
+          "415" : {
+            "description" : "Unsupported media type",
             "content" : {
               "application/json" : {
                 "schema" : {
@@ -623,20 +623,8 @@
               }
             }
           },
-          "200" : {
-            "description" : "Returns the paged result found for Asset",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "maxItems" : 2147483647,
-                  "minItems" : 0,
-                  "type" : "array"
-                }
-              }
-            }
-          },
-          "404" : {
-            "description" : "Not found.",
+          "403" : {
+            "description" : "Forbidden.",
             "content" : {
               "application/json" : {
                 "schema" : {
@@ -655,32 +643,44 @@
               }
             }
           },
-          "403" : {
-            "description" : "Forbidden.",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "415" : {
-            "description" : "Unsupported media type",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
           "400" : {
             "description" : "Bad request.",
             "content" : {
               "application/json" : {
                 "schema" : {
                   "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404" : {
+            "description" : "Not found.",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "429" : {
+            "description" : "Too many requests.",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "200" : {
+            "description" : "Returns the paged result found for Asset",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "maxItems" : 2147483647,
+                  "minItems" : 0,
+                  "type" : "array"
                 }
               }
             }
@@ -712,8 +712,8 @@
           "required" : true
         },
         "responses" : {
-          "429" : {
-            "description" : "Too many requests.",
+          "415" : {
+            "description" : "Unsupported media type",
             "content" : {
               "application/json" : {
                 "schema" : {
@@ -732,8 +732,8 @@
               }
             }
           },
-          "404" : {
-            "description" : "Not found.",
+          "403" : {
+            "description" : "Forbidden.",
             "content" : {
               "application/json" : {
                 "schema" : {
@@ -752,8 +752,8 @@
               }
             }
           },
-          "403" : {
-            "description" : "Forbidden.",
+          "400" : {
+            "description" : "Bad request.",
             "content" : {
               "application/json" : {
                 "schema" : {
@@ -762,8 +762,18 @@
               }
             }
           },
-          "415" : {
-            "description" : "Unsupported media type",
+          "404" : {
+            "description" : "Not found.",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "429" : {
+            "description" : "Too many requests.",
             "content" : {
               "application/json" : {
                 "schema" : {
@@ -778,16 +788,6 @@
               "application/json" : {
                 "schema" : {
                   "$ref" : "#/components/schemas/QualityNotificationIdResponse"
-                }
-              }
-            }
-          },
-          "400" : {
-            "description" : "Bad request.",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -832,8 +832,8 @@
           "required" : true
         },
         "responses" : {
-          "429" : {
-            "description" : "Too many requests.",
+          "415" : {
+            "description" : "Unsupported media type",
             "content" : {
               "application/json" : {
                 "schema" : {
@@ -852,8 +852,8 @@
               }
             }
           },
-          "404" : {
-            "description" : "Not found.",
+          "403" : {
+            "description" : "Forbidden.",
             "content" : {
               "application/json" : {
                 "schema" : {
@@ -861,9 +861,6 @@
                 }
               }
             }
-          },
-          "204" : {
-            "description" : "No content."
           },
           "401" : {
             "description" : "Authorization failed.",
@@ -875,28 +872,31 @@
               }
             }
           },
-          "403" : {
-            "description" : "Forbidden.",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "415" : {
-            "description" : "Unsupported media type",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
+          "204" : {
+            "description" : "No content."
           },
           "400" : {
             "description" : "Bad request.",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404" : {
+            "description" : "Not found.",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "429" : {
+            "description" : "Too many requests.",
             "content" : {
               "application/json" : {
                 "schema" : {
@@ -945,8 +945,8 @@
           "required" : true
         },
         "responses" : {
-          "429" : {
-            "description" : "Too many requests.",
+          "415" : {
+            "description" : "Unsupported media type",
             "content" : {
               "application/json" : {
                 "schema" : {
@@ -965,8 +965,8 @@
               }
             }
           },
-          "404" : {
-            "description" : "Not found.",
+          "403" : {
+            "description" : "Forbidden.",
             "content" : {
               "application/json" : {
                 "schema" : {
@@ -974,9 +974,6 @@
                 }
               }
             }
-          },
-          "204" : {
-            "description" : "No content."
           },
           "401" : {
             "description" : "Authorization failed.",
@@ -988,28 +985,31 @@
               }
             }
           },
-          "403" : {
-            "description" : "Forbidden.",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "415" : {
-            "description" : "Unsupported media type",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
+          "204" : {
+            "description" : "No content."
           },
           "400" : {
             "description" : "Bad request.",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404" : {
+            "description" : "Not found.",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "429" : {
+            "description" : "Too many requests.",
             "content" : {
               "application/json" : {
                 "schema" : {
@@ -1048,8 +1048,8 @@
           }
         ],
         "responses" : {
-          "429" : {
-            "description" : "Too many requests.",
+          "415" : {
+            "description" : "Unsupported media type",
             "content" : {
               "application/json" : {
                 "schema" : {
@@ -1068,29 +1068,6 @@
               }
             }
           },
-          "404" : {
-            "description" : "Not found.",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "204" : {
-            "description" : "No content."
-          },
-          "401" : {
-            "description" : "Authorization failed.",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
           "403" : {
             "description" : "Forbidden.",
             "content" : {
@@ -1101,8 +1078,8 @@
               }
             }
           },
-          "415" : {
-            "description" : "Unsupported media type",
+          "401" : {
+            "description" : "Authorization failed.",
             "content" : {
               "application/json" : {
                 "schema" : {
@@ -1120,6 +1097,29 @@
                 }
               }
             }
+          },
+          "404" : {
+            "description" : "Not found.",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "429" : {
+            "description" : "Too many requests.",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "204" : {
+            "description" : "No content."
           }
         },
         "security" : [
@@ -1151,8 +1151,8 @@
           }
         ],
         "responses" : {
-          "429" : {
-            "description" : "Too many requests.",
+          "415" : {
+            "description" : "Unsupported media type",
             "content" : {
               "application/json" : {
                 "schema" : {
@@ -1171,8 +1171,8 @@
               }
             }
           },
-          "404" : {
-            "description" : "Not found.",
+          "403" : {
+            "description" : "Forbidden.",
             "content" : {
               "application/json" : {
                 "schema" : {
@@ -1180,9 +1180,6 @@
                 }
               }
             }
-          },
-          "204" : {
-            "description" : "No content."
           },
           "401" : {
             "description" : "Authorization failed.",
@@ -1194,28 +1191,31 @@
               }
             }
           },
-          "403" : {
-            "description" : "Forbidden.",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "415" : {
-            "description" : "Unsupported media type",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
+          "204" : {
+            "description" : "No content."
           },
           "400" : {
             "description" : "Bad request.",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404" : {
+            "description" : "Not found.",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "429" : {
+            "description" : "Too many requests.",
             "content" : {
               "application/json" : {
                 "schema" : {
@@ -1253,8 +1253,8 @@
           "required" : true
         },
         "responses" : {
-          "429" : {
-            "description" : "Too many requests.",
+          "415" : {
+            "description" : "Unsupported media type",
             "content" : {
               "application/json" : {
                 "schema" : {
@@ -1273,8 +1273,8 @@
               }
             }
           },
-          "404" : {
-            "description" : "Not found.",
+          "403" : {
+            "description" : "Forbidden.",
             "content" : {
               "application/json" : {
                 "schema" : {
@@ -1293,8 +1293,8 @@
               }
             }
           },
-          "403" : {
-            "description" : "Forbidden.",
+          "400" : {
+            "description" : "Bad request.",
             "content" : {
               "application/json" : {
                 "schema" : {
@@ -1303,8 +1303,18 @@
               }
             }
           },
-          "415" : {
-            "description" : "Unsupported media type",
+          "404" : {
+            "description" : "Not found.",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "429" : {
+            "description" : "Too many requests.",
             "content" : {
               "application/json" : {
                 "schema" : {
@@ -1319,16 +1329,6 @@
               "application/json" : {
                 "schema" : {
                   "$ref" : "#/components/schemas/CreateNotificationContractResponse"
-                }
-              }
-            }
-          },
-          "400" : {
-            "description" : "Bad request.",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -1362,8 +1362,8 @@
           "required" : true
         },
         "responses" : {
-          "429" : {
-            "description" : "Too many requests.",
+          "415" : {
+            "description" : "Unsupported media type",
             "content" : {
               "application/json" : {
                 "schema" : {
@@ -1382,8 +1382,8 @@
               }
             }
           },
-          "404" : {
-            "description" : "Not found.",
+          "403" : {
+            "description" : "Forbidden.",
             "content" : {
               "application/json" : {
                 "schema" : {
@@ -1402,8 +1402,8 @@
               }
             }
           },
-          "403" : {
-            "description" : "Forbidden.",
+          "400" : {
+            "description" : "Bad request.",
             "content" : {
               "application/json" : {
                 "schema" : {
@@ -1412,8 +1412,18 @@
               }
             }
           },
-          "415" : {
-            "description" : "Unsupported media type",
+          "404" : {
+            "description" : "Not found.",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "429" : {
+            "description" : "Too many requests.",
             "content" : {
               "application/json" : {
                 "schema" : {
@@ -1424,16 +1434,6 @@
           },
           "201" : {
             "description" : "Created."
-          },
-          "400" : {
-            "description" : "Bad request.",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
           }
         },
         "security" : [
@@ -1464,20 +1464,8 @@
           "required" : true
         },
         "responses" : {
-          "200" : {
-            "description" : "Returns the paged result found for Asset",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "maxItems" : 2147483647,
-                  "minItems" : 0,
-                  "type" : "array"
-                }
-              }
-            }
-          },
-          "429" : {
-            "description" : "Too many requests.",
+          "415" : {
+            "description" : "Unsupported media type",
             "content" : {
               "application/json" : {
                 "schema" : {
@@ -1496,12 +1484,24 @@
               }
             }
           },
-          "404" : {
-            "description" : "Not found.",
+          "403" : {
+            "description" : "Forbidden.",
             "content" : {
               "application/json" : {
                 "schema" : {
                   "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "200" : {
+            "description" : "Returns the paged result found for Asset",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "maxItems" : 2147483647,
+                  "minItems" : 0,
+                  "type" : "array"
                 }
               }
             }
@@ -1516,28 +1516,28 @@
               }
             }
           },
-          "403" : {
-            "description" : "Forbidden.",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "415" : {
-            "description" : "Unsupported media type",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
           "400" : {
             "description" : "Bad request.",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404" : {
+            "description" : "Not found.",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "429" : {
+            "description" : "Too many requests.",
             "content" : {
               "application/json" : {
                 "schema" : {
@@ -1575,8 +1575,8 @@
           "required" : true
         },
         "responses" : {
-          "429" : {
-            "description" : "Too many requests.",
+          "415" : {
+            "description" : "Unsupported media type",
             "content" : {
               "application/json" : {
                 "schema" : {
@@ -1595,8 +1595,8 @@
               }
             }
           },
-          "404" : {
-            "description" : "Not found.",
+          "403" : {
+            "description" : "Forbidden.",
             "content" : {
               "application/json" : {
                 "schema" : {
@@ -1615,8 +1615,8 @@
               }
             }
           },
-          "403" : {
-            "description" : "Forbidden.",
+          "400" : {
+            "description" : "Bad request.",
             "content" : {
               "application/json" : {
                 "schema" : {
@@ -1625,8 +1625,18 @@
               }
             }
           },
-          "415" : {
-            "description" : "Unsupported media type",
+          "404" : {
+            "description" : "Not found.",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "429" : {
+            "description" : "Too many requests.",
             "content" : {
               "application/json" : {
                 "schema" : {
@@ -1637,16 +1647,6 @@
           },
           "201" : {
             "description" : "Created."
-          },
-          "400" : {
-            "description" : "Bad request.",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
           }
         },
         "security" : [
@@ -1677,16 +1677,6 @@
           "required" : true
         },
         "responses" : {
-          "429" : {
-            "description" : "Too many requests.",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
           "200" : {
             "description" : "Returns the paged result found for Asset",
             "content" : {
@@ -1699,28 +1689,18 @@
               }
             }
           },
+          "415" : {
+            "description" : "Unsupported media type",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
           "500" : {
             "description" : "Internal server error.",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "404" : {
-            "description" : "Not found.",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "401" : {
-            "description" : "Authorization failed.",
             "content" : {
               "application/json" : {
                 "schema" : {
@@ -1739,8 +1719,8 @@
               }
             }
           },
-          "415" : {
-            "description" : "Unsupported media type",
+          "401" : {
+            "description" : "Authorization failed.",
             "content" : {
               "application/json" : {
                 "schema" : {
@@ -1751,6 +1731,26 @@
           },
           "400" : {
             "description" : "Bad request.",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404" : {
+            "description" : "Not found.",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "429" : {
+            "description" : "Too many requests.",
             "content" : {
               "application/json" : {
                 "schema" : {
@@ -1796,8 +1796,8 @@
           }
         ],
         "responses" : {
-          "429" : {
-            "description" : "Too many requests.",
+          "415" : {
+            "description" : "Unsupported media type",
             "content" : {
               "application/json" : {
                 "schema" : {
@@ -1816,19 +1816,8 @@
               }
             }
           },
-          "200" : {
-            "description" : "Returns the paged result found for Asset",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "maxItems" : 2147483647,
-                  "type" : "array"
-                }
-              }
-            }
-          },
-          "404" : {
-            "description" : "Not found.",
+          "403" : {
+            "description" : "Forbidden.",
             "content" : {
               "application/json" : {
                 "schema" : {
@@ -1847,32 +1836,43 @@
               }
             }
           },
-          "403" : {
-            "description" : "Forbidden.",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "415" : {
-            "description" : "Unsupported media type",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
           "400" : {
             "description" : "Bad request.",
             "content" : {
               "application/json" : {
                 "schema" : {
                   "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404" : {
+            "description" : "Not found.",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "429" : {
+            "description" : "Too many requests.",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "200" : {
+            "description" : "Returns the paged result found for Asset",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "maxItems" : 2147483647,
+                  "type" : "array"
                 }
               }
             }
@@ -1904,8 +1904,8 @@
           "required" : true
         },
         "responses" : {
-          "429" : {
-            "description" : "Too many requests.",
+          "415" : {
+            "description" : "Unsupported media type",
             "content" : {
               "application/json" : {
                 "schema" : {
@@ -1924,8 +1924,8 @@
               }
             }
           },
-          "404" : {
-            "description" : "Not found.",
+          "403" : {
+            "description" : "Forbidden.",
             "content" : {
               "application/json" : {
                 "schema" : {
@@ -1944,8 +1944,8 @@
               }
             }
           },
-          "403" : {
-            "description" : "Forbidden.",
+          "400" : {
+            "description" : "Bad request.",
             "content" : {
               "application/json" : {
                 "schema" : {
@@ -1954,8 +1954,18 @@
               }
             }
           },
-          "415" : {
-            "description" : "Unsupported media type",
+          "404" : {
+            "description" : "Not found.",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "429" : {
+            "description" : "Too many requests.",
             "content" : {
               "application/json" : {
                 "schema" : {
@@ -1970,16 +1980,6 @@
               "application/json" : {
                 "schema" : {
                   "$ref" : "#/components/schemas/QualityNotificationIdResponse"
-                }
-              }
-            }
-          },
-          "400" : {
-            "description" : "Bad request.",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -2024,8 +2024,8 @@
           "required" : true
         },
         "responses" : {
-          "429" : {
-            "description" : "Too many requests.",
+          "415" : {
+            "description" : "Unsupported media type",
             "content" : {
               "application/json" : {
                 "schema" : {
@@ -2044,8 +2044,8 @@
               }
             }
           },
-          "404" : {
-            "description" : "Not found.",
+          "403" : {
+            "description" : "Forbidden.",
             "content" : {
               "application/json" : {
                 "schema" : {
@@ -2053,9 +2053,6 @@
                 }
               }
             }
-          },
-          "204" : {
-            "description" : "No content."
           },
           "401" : {
             "description" : "Authorization failed.",
@@ -2067,28 +2064,31 @@
               }
             }
           },
-          "403" : {
-            "description" : "Forbidden.",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "415" : {
-            "description" : "Unsupported media type",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
+          "204" : {
+            "description" : "No content."
           },
           "400" : {
             "description" : "Bad request.",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404" : {
+            "description" : "Not found.",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "429" : {
+            "description" : "Too many requests.",
             "content" : {
               "application/json" : {
                 "schema" : {
@@ -2137,8 +2137,8 @@
           "required" : true
         },
         "responses" : {
-          "429" : {
-            "description" : "Too many requests.",
+          "415" : {
+            "description" : "Unsupported media type",
             "content" : {
               "application/json" : {
                 "schema" : {
@@ -2157,8 +2157,8 @@
               }
             }
           },
-          "404" : {
-            "description" : "Not found.",
+          "403" : {
+            "description" : "Forbidden.",
             "content" : {
               "application/json" : {
                 "schema" : {
@@ -2166,9 +2166,6 @@
                 }
               }
             }
-          },
-          "204" : {
-            "description" : "No content."
           },
           "401" : {
             "description" : "Authorization failed.",
@@ -2180,28 +2177,31 @@
               }
             }
           },
-          "403" : {
-            "description" : "Forbidden.",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "415" : {
-            "description" : "Unsupported media type",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
+          "204" : {
+            "description" : "No content."
           },
           "400" : {
             "description" : "Bad request.",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404" : {
+            "description" : "Not found.",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "429" : {
+            "description" : "Too many requests.",
             "content" : {
               "application/json" : {
                 "schema" : {
@@ -2240,8 +2240,8 @@
           }
         ],
         "responses" : {
-          "429" : {
-            "description" : "Too many requests.",
+          "415" : {
+            "description" : "Unsupported media type",
             "content" : {
               "application/json" : {
                 "schema" : {
@@ -2260,8 +2260,8 @@
               }
             }
           },
-          "404" : {
-            "description" : "Not found.",
+          "403" : {
+            "description" : "Forbidden.",
             "content" : {
               "application/json" : {
                 "schema" : {
@@ -2269,9 +2269,6 @@
                 }
               }
             }
-          },
-          "204" : {
-            "description" : "No content."
           },
           "401" : {
             "description" : "Authorization failed.",
@@ -2283,28 +2280,31 @@
               }
             }
           },
-          "403" : {
-            "description" : "Forbidden.",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "415" : {
-            "description" : "Unsupported media type",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
+          "204" : {
+            "description" : "No content."
           },
           "400" : {
             "description" : "Bad request.",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404" : {
+            "description" : "Not found.",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "429" : {
+            "description" : "Too many requests.",
             "content" : {
               "application/json" : {
                 "schema" : {
@@ -2343,8 +2343,8 @@
           }
         ],
         "responses" : {
-          "429" : {
-            "description" : "Too many requests.",
+          "415" : {
+            "description" : "Unsupported media type",
             "content" : {
               "application/json" : {
                 "schema" : {
@@ -2363,29 +2363,6 @@
               }
             }
           },
-          "404" : {
-            "description" : "Not found.",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "204" : {
-            "description" : "No content."
-          },
-          "401" : {
-            "description" : "Authorization failed.",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
           "403" : {
             "description" : "Forbidden.",
             "content" : {
@@ -2396,8 +2373,8 @@
               }
             }
           },
-          "415" : {
-            "description" : "Unsupported media type",
+          "401" : {
+            "description" : "Authorization failed.",
             "content" : {
               "application/json" : {
                 "schema" : {
@@ -2415,6 +2392,29 @@
                 }
               }
             }
+          },
+          "404" : {
+            "description" : "Not found.",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "429" : {
+            "description" : "Too many requests.",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "204" : {
+            "description" : "No content."
           }
         },
         "security" : [
@@ -2445,8 +2445,8 @@
           }
         ],
         "responses" : {
-          "429" : {
-            "description" : "Too many requests.",
+          "415" : {
+            "description" : "Unsupported media type",
             "content" : {
               "application/json" : {
                 "schema" : {
@@ -2465,8 +2465,8 @@
               }
             }
           },
-          "404" : {
-            "description" : "Not found.",
+          "403" : {
+            "description" : "Forbidden.",
             "content" : {
               "application/json" : {
                 "schema" : {
@@ -2485,8 +2485,8 @@
               }
             }
           },
-          "403" : {
-            "description" : "Forbidden.",
+          "400" : {
+            "description" : "Bad request.",
             "content" : {
               "application/json" : {
                 "schema" : {
@@ -2495,8 +2495,18 @@
               }
             }
           },
-          "415" : {
-            "description" : "Unsupported media type",
+          "404" : {
+            "description" : "Not found.",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "429" : {
+            "description" : "Too many requests.",
             "content" : {
               "application/json" : {
                 "schema" : {
@@ -2637,16 +2647,6 @@
                 }
               }
             }
-          },
-          "400" : {
-            "description" : "Bad request.",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
           }
         },
         "security" : [
@@ -2685,8 +2685,8 @@
           "required" : true
         },
         "responses" : {
-          "429" : {
-            "description" : "Too many requests.",
+          "415" : {
+            "description" : "Unsupported media type",
             "content" : {
               "application/json" : {
                 "schema" : {
@@ -2697,46 +2697,6 @@
           },
           "500" : {
             "description" : "Internal server error.",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "404" : {
-            "description" : "Not found.",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "401" : {
-            "description" : "Authorization failed.",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "403" : {
-            "description" : "Forbidden.",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "415" : {
-            "description" : "Unsupported media type",
             "content" : {
               "application/json" : {
                 "schema" : {
@@ -2878,8 +2838,48 @@
               }
             }
           },
+          "403" : {
+            "description" : "Forbidden.",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401" : {
+            "description" : "Authorization failed.",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
           "400" : {
             "description" : "Bad request.",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404" : {
+            "description" : "Not found.",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "429" : {
+            "description" : "Too many requests.",
             "content" : {
               "application/json" : {
                 "schema" : {
@@ -2917,6 +2917,56 @@
           }
         ],
         "responses" : {
+          "415" : {
+            "description" : "Unsupported media type",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500" : {
+            "description" : "Internal server error.",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403" : {
+            "description" : "Forbidden.",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401" : {
+            "description" : "Authorization failed.",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "400" : {
+            "description" : "Bad request.",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
           "200" : {
             "description" : "Returns the assets found",
             "content" : {
@@ -3050,26 +3100,6 @@
               }
             }
           },
-          "429" : {
-            "description" : "Too many requests.",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "500" : {
-            "description" : "Internal server error.",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
           "404" : {
             "description" : "Not found.",
             "content" : {
@@ -3080,38 +3110,8 @@
               }
             }
           },
-          "401" : {
-            "description" : "Authorization failed.",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "403" : {
-            "description" : "Forbidden.",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "415" : {
-            "description" : "Unsupported media type",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "400" : {
-            "description" : "Bad request.",
+          "429" : {
+            "description" : "Too many requests.",
             "content" : {
               "application/json" : {
                 "schema" : {
@@ -3157,36 +3157,6 @@
           "required" : true
         },
         "responses" : {
-          "429" : {
-            "description" : "Too many requests.",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "500" : {
-            "description" : "Internal server error.",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "404" : {
-            "description" : "Not found.",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
           "200" : {
             "description" : "Returns the updated asset",
             "content" : {
@@ -3320,8 +3290,18 @@
               }
             }
           },
-          "401" : {
-            "description" : "Authorization failed.",
+          "415" : {
+            "description" : "Unsupported media type",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500" : {
+            "description" : "Internal server error.",
             "content" : {
               "application/json" : {
                 "schema" : {
@@ -3340,8 +3320,8 @@
               }
             }
           },
-          "415" : {
-            "description" : "Unsupported media type",
+          "401" : {
+            "description" : "Authorization failed.",
             "content" : {
               "application/json" : {
                 "schema" : {
@@ -3352,6 +3332,26 @@
           },
           "400" : {
             "description" : "Bad request.",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404" : {
+            "description" : "Not found.",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "429" : {
+            "description" : "Too many requests.",
             "content" : {
               "application/json" : {
                 "schema" : {
@@ -3379,8 +3379,8 @@
         "description" : "The endpoint returns all shell descriptors.",
         "operationId" : "findAll",
         "responses" : {
-          "429" : {
-            "description" : "Too many requests.",
+          "415" : {
+            "description" : "Unsupported media type",
             "content" : {
               "application/json" : {
                 "schema" : {
@@ -3399,8 +3399,28 @@
               }
             }
           },
-          "404" : {
-            "description" : "Not found.",
+          "403" : {
+            "description" : "Forbidden.",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401" : {
+            "description" : "Authorization failed.",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "400" : {
+            "description" : "Bad request.",
             "content" : {
               "application/json" : {
                 "schema" : {
@@ -3422,8 +3442,8 @@
               }
             }
           },
-          "401" : {
-            "description" : "Authorization failed.",
+          "404" : {
+            "description" : "Not found.",
             "content" : {
               "application/json" : {
                 "schema" : {
@@ -3432,28 +3452,8 @@
               }
             }
           },
-          "403" : {
-            "description" : "Forbidden.",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "415" : {
-            "description" : "Unsupported media type",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "400" : {
-            "description" : "Bad request.",
+          "429" : {
+            "description" : "Too many requests.",
             "content" : {
               "application/json" : {
                 "schema" : {
@@ -3480,8 +3480,8 @@
         "description" : "The endpoint deletes all shell descriptors.",
         "operationId" : "deleteAll",
         "responses" : {
-          "429" : {
-            "description" : "Too many requests.",
+          "415" : {
+            "description" : "Unsupported media type",
             "content" : {
               "application/json" : {
                 "schema" : {
@@ -3503,8 +3503,8 @@
           "204" : {
             "description" : "Deleted."
           },
-          "404" : {
-            "description" : "Not found.",
+          "403" : {
+            "description" : "Forbidden.",
             "content" : {
               "application/json" : {
                 "schema" : {
@@ -3523,28 +3523,28 @@
               }
             }
           },
-          "403" : {
-            "description" : "Forbidden.",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "415" : {
-            "description" : "Unsupported media type",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
           "400" : {
             "description" : "Bad request.",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404" : {
+            "description" : "Not found.",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "429" : {
+            "description" : "Too many requests.",
             "content" : {
               "application/json" : {
                 "schema" : {
@@ -3572,8 +3572,8 @@
         "description" : "The endpoint Triggers reload of shell descriptors.",
         "operationId" : "reload",
         "responses" : {
-          "429" : {
-            "description" : "Too many requests.",
+          "415" : {
+            "description" : "Unsupported media type",
             "content" : {
               "application/json" : {
                 "schema" : {
@@ -3592,8 +3592,8 @@
               }
             }
           },
-          "404" : {
-            "description" : "Not found.",
+          "403" : {
+            "description" : "Forbidden.",
             "content" : {
               "application/json" : {
                 "schema" : {
@@ -3601,9 +3601,6 @@
                 }
               }
             }
-          },
-          "202" : {
-            "description" : "Created registry reload job."
           },
           "401" : {
             "description" : "Authorization failed.",
@@ -3615,28 +3612,31 @@
               }
             }
           },
-          "403" : {
-            "description" : "Forbidden.",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "415" : {
-            "description" : "Unsupported media type",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
+          "202" : {
+            "description" : "Created registry reload job."
           },
           "400" : {
             "description" : "Bad request.",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404" : {
+            "description" : "Not found.",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "429" : {
+            "description" : "Too many requests.",
             "content" : {
               "application/json" : {
                 "schema" : {
@@ -3675,8 +3675,8 @@
           }
         ],
         "responses" : {
-          "429" : {
-            "description" : "Too many requests.",
+          "415" : {
+            "description" : "Unsupported media type",
             "content" : {
               "application/json" : {
                 "schema" : {
@@ -3711,8 +3711,8 @@
               }
             }
           },
-          "404" : {
-            "description" : "Not found.",
+          "403" : {
+            "description" : "Forbidden.",
             "content" : {
               "application/json" : {
                 "schema" : {
@@ -3731,28 +3731,28 @@
               }
             }
           },
-          "403" : {
-            "description" : "Forbidden.",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "415" : {
-            "description" : "Unsupported media type",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
           "400" : {
             "description" : "Bad request.",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404" : {
+            "description" : "Not found.",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "429" : {
+            "description" : "Too many requests.",
             "content" : {
               "application/json" : {
                 "schema" : {
@@ -3780,8 +3780,8 @@
         "description" : "The endpoint can return limited data based on the user role",
         "operationId" : "dashboard",
         "responses" : {
-          "429" : {
-            "description" : "Too many requests.",
+          "415" : {
+            "description" : "Unsupported media type",
             "content" : {
               "application/json" : {
                 "schema" : {
@@ -3800,8 +3800,8 @@
               }
             }
           },
-          "404" : {
-            "description" : "Not found.",
+          "403" : {
+            "description" : "Forbidden.",
             "content" : {
               "application/json" : {
                 "schema" : {
@@ -3830,28 +3830,28 @@
               }
             }
           },
-          "403" : {
-            "description" : "Forbidden.",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "415" : {
-            "description" : "Unsupported media type",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
           "400" : {
             "description" : "Bad request.",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404" : {
+            "description" : "Not found.",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "429" : {
+            "description" : "Too many requests.",
             "content" : {
               "application/json" : {
                 "schema" : {
@@ -3897,8 +3897,8 @@
           }
         ],
         "responses" : {
-          "429" : {
-            "description" : "Too many requests.",
+          "415" : {
+            "description" : "Unsupported media type",
             "content" : {
               "application/json" : {
                 "schema" : {
@@ -3909,16 +3909,6 @@
           },
           "500" : {
             "description" : "Internal server error.",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "404" : {
-            "description" : "Not found.",
             "content" : {
               "application/json" : {
                 "schema" : {
@@ -4065,16 +4055,6 @@
               }
             }
           },
-          "401" : {
-            "description" : "Authorization failed.",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
           "403" : {
             "description" : "Forbidden.",
             "content" : {
@@ -4085,8 +4065,8 @@
               }
             }
           },
-          "415" : {
-            "description" : "Unsupported media type",
+          "401" : {
+            "description" : "Authorization failed.",
             "content" : {
               "application/json" : {
                 "schema" : {
@@ -4097,6 +4077,26 @@
           },
           "400" : {
             "description" : "Bad request.",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404" : {
+            "description" : "Not found.",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "429" : {
+            "description" : "Too many requests.",
             "content" : {
               "application/json" : {
                 "schema" : {
@@ -4275,8 +4275,8 @@
               }
             }
           },
-          "429" : {
-            "description" : "Too many requests.",
+          "415" : {
+            "description" : "Unsupported media type",
             "content" : {
               "application/json" : {
                 "schema" : {
@@ -4295,8 +4295,8 @@
               }
             }
           },
-          "404" : {
-            "description" : "Not found.",
+          "403" : {
+            "description" : "Forbidden.",
             "content" : {
               "application/json" : {
                 "schema" : {
@@ -4315,28 +4315,28 @@
               }
             }
           },
-          "403" : {
-            "description" : "Forbidden.",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "415" : {
-            "description" : "Unsupported media type",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
           "400" : {
             "description" : "Bad request.",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404" : {
+            "description" : "Not found.",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "429" : {
+            "description" : "Too many requests.",
             "content" : {
               "application/json" : {
                 "schema" : {
@@ -4392,8 +4392,20 @@
           }
         ],
         "responses" : {
-          "429" : {
-            "description" : "Too many requests.",
+          "200" : {
+            "description" : "Returns a distinct filter values for given fieldName.",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "maxItems" : 2147483647,
+                  "minItems" : 0,
+                  "type" : "array"
+                }
+              }
+            }
+          },
+          "415" : {
+            "description" : "Unsupported media type",
             "content" : {
               "application/json" : {
                 "schema" : {
@@ -4412,8 +4424,8 @@
               }
             }
           },
-          "404" : {
-            "description" : "Not found.",
+          "403" : {
+            "description" : "Forbidden.",
             "content" : {
               "application/json" : {
                 "schema" : {
@@ -4432,40 +4444,28 @@
               }
             }
           },
-          "403" : {
-            "description" : "Forbidden.",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "415" : {
-            "description" : "Unsupported media type",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "200" : {
-            "description" : "Returns a distinct filter values for given fieldName.",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "maxItems" : 2147483647,
-                  "minItems" : 0,
-                  "type" : "array"
-                }
-              }
-            }
-          },
           "400" : {
             "description" : "Bad request.",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404" : {
+            "description" : "Not found.",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "429" : {
+            "description" : "Too many requests.",
             "content" : {
               "application/json" : {
                 "schema" : {
@@ -4511,8 +4511,8 @@
           }
         ],
         "responses" : {
-          "429" : {
-            "description" : "Too many requests.",
+          "415" : {
+            "description" : "Unsupported media type",
             "content" : {
               "application/json" : {
                 "schema" : {
@@ -4531,8 +4531,8 @@
               }
             }
           },
-          "404" : {
-            "description" : "Not found.",
+          "403" : {
+            "description" : "Forbidden.",
             "content" : {
               "application/json" : {
                 "schema" : {
@@ -4551,8 +4551,8 @@
               }
             }
           },
-          "403" : {
-            "description" : "Forbidden.",
+          "400" : {
+            "description" : "Bad request.",
             "content" : {
               "application/json" : {
                 "schema" : {
@@ -4561,8 +4561,18 @@
               }
             }
           },
-          "415" : {
-            "description" : "Unsupported media type",
+          "404" : {
+            "description" : "Not found.",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "429" : {
+            "description" : "Too many requests.",
             "content" : {
               "application/json" : {
                 "schema" : {
@@ -4708,16 +4718,6 @@
                 }
               }
             }
-          },
-          "400" : {
-            "description" : "Bad request.",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
           }
         },
         "security" : [
@@ -4756,6 +4756,76 @@
           }
         ],
         "responses" : {
+          "415" : {
+            "description" : "Unsupported media type",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500" : {
+            "description" : "Internal server error.",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403" : {
+            "description" : "Forbidden.",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401" : {
+            "description" : "Authorization failed.",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "400" : {
+            "description" : "Bad request.",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404" : {
+            "description" : "Not found.",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "429" : {
+            "description" : "Too many requests.",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
           "200" : {
             "description" : "Returns the asset by childId",
             "content" : {
@@ -4888,76 +4958,6 @@
                 }
               }
             }
-          },
-          "429" : {
-            "description" : "Too many requests.",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "500" : {
-            "description" : "Internal server error.",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "404" : {
-            "description" : "Not found.",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "401" : {
-            "description" : "Authorization failed.",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "403" : {
-            "description" : "Forbidden.",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "415" : {
-            "description" : "Unsupported media type",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "400" : {
-            "description" : "Bad request.",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
           }
         },
         "security" : [
@@ -5006,8 +5006,20 @@
           }
         ],
         "responses" : {
-          "429" : {
-            "description" : "Too many requests.",
+          "200" : {
+            "description" : "Returns a distinct filter values for given fieldName.",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "maxItems" : 2147483647,
+                  "minItems" : 0,
+                  "type" : "array"
+                }
+              }
+            }
+          },
+          "415" : {
+            "description" : "Unsupported media type",
             "content" : {
               "application/json" : {
                 "schema" : {
@@ -5026,8 +5038,8 @@
               }
             }
           },
-          "404" : {
-            "description" : "Not found.",
+          "403" : {
+            "description" : "Forbidden.",
             "content" : {
               "application/json" : {
                 "schema" : {
@@ -5046,40 +5058,28 @@
               }
             }
           },
-          "403" : {
-            "description" : "Forbidden.",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "415" : {
-            "description" : "Unsupported media type",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "200" : {
-            "description" : "Returns a distinct filter values for given fieldName.",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "maxItems" : 2147483647,
-                  "minItems" : 0,
-                  "type" : "array"
-                }
-              }
-            }
-          },
           "400" : {
             "description" : "Bad request.",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404" : {
+            "description" : "Not found.",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "429" : {
+            "description" : "Too many requests.",
             "content" : {
               "application/json" : {
                 "schema" : {
@@ -5107,8 +5107,8 @@
         "description" : "The endpoint returns a map for assets consumed by the map.",
         "operationId" : "assetsCountryMap",
         "responses" : {
-          "429" : {
-            "description" : "Too many requests.",
+          "415" : {
+            "description" : "Unsupported media type",
             "content" : {
               "application/json" : {
                 "schema" : {
@@ -5141,8 +5141,8 @@
               }
             }
           },
-          "404" : {
-            "description" : "Not found.",
+          "403" : {
+            "description" : "Forbidden.",
             "content" : {
               "application/json" : {
                 "schema" : {
@@ -5161,28 +5161,28 @@
               }
             }
           },
-          "403" : {
-            "description" : "Forbidden.",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "415" : {
-            "description" : "Unsupported media type",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
           "400" : {
             "description" : "Bad request.",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404" : {
+            "description" : "Not found.",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "429" : {
+            "description" : "Too many requests.",
             "content" : {
               "application/json" : {
                 "schema" : {
@@ -5221,8 +5221,8 @@
           }
         ],
         "responses" : {
-          "429" : {
-            "description" : "Too many requests.",
+          "415" : {
+            "description" : "Unsupported media type",
             "content" : {
               "application/json" : {
                 "schema" : {
@@ -5256,8 +5256,8 @@
               }
             }
           },
-          "404" : {
-            "description" : "Not found.",
+          "403" : {
+            "description" : "Forbidden.",
             "content" : {
               "application/json" : {
                 "schema" : {
@@ -5276,28 +5276,28 @@
               }
             }
           },
-          "403" : {
-            "description" : "Forbidden.",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "415" : {
-            "description" : "Unsupported media type",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
           "400" : {
             "description" : "Bad request.",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404" : {
+            "description" : "Not found.",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "429" : {
+            "description" : "Too many requests.",
             "content" : {
               "application/json" : {
                 "schema" : {
@@ -5325,8 +5325,8 @@
         "description" : "Deletes all submodels from the system.",
         "operationId" : "deleteSubmodels",
         "responses" : {
-          "429" : {
-            "description" : "Too many requests.",
+          "415" : {
+            "description" : "Unsupported media type",
             "content" : {
               "application/json" : {
                 "schema" : {
@@ -5345,29 +5345,6 @@
               }
             }
           },
-          "404" : {
-            "description" : "Not found.",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "204" : {
-            "description" : "No Content."
-          },
-          "401" : {
-            "description" : "Authorization failed.",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
           "403" : {
             "description" : "Forbidden.",
             "content" : {
@@ -5378,8 +5355,8 @@
               }
             }
           },
-          "415" : {
-            "description" : "Unsupported media type",
+          "401" : {
+            "description" : "Authorization failed.",
             "content" : {
               "application/json" : {
                 "schema" : {
@@ -5397,6 +5374,29 @@
                 }
               }
             }
+          },
+          "404" : {
+            "description" : "Not found.",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "429" : {
+            "description" : "Too many requests.",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "204" : {
+            "description" : "No Content."
           }
         },
         "security" : [
@@ -5427,11 +5427,8 @@
           }
         ],
         "responses" : {
-          "204" : {
-            "description" : "Deleted."
-          },
-          "429" : {
-            "description" : "Too many requests.",
+          "415" : {
+            "description" : "Unsupported media type",
             "content" : {
               "application/json" : {
                 "schema" : {
@@ -5450,8 +5447,8 @@
               }
             }
           },
-          "404" : {
-            "description" : "Not found.",
+          "403" : {
+            "description" : "Forbidden.",
             "content" : {
               "application/json" : {
                 "schema" : {
@@ -5470,26 +5467,6 @@
               }
             }
           },
-          "403" : {
-            "description" : "Forbidden.",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "415" : {
-            "description" : "Unsupported media type",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
           "400" : {
             "description" : "Bad request.",
             "content" : {
@@ -5499,6 +5476,29 @@
                 }
               }
             }
+          },
+          "404" : {
+            "description" : "Not found.",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "429" : {
+            "description" : "Too many requests.",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "204" : {
+            "description" : "Deleted."
           }
         },
         "security" : [

--- a/tx-backend/src/main/java/org/eclipse/tractusx/traceability/assets/application/asbuilt/mapper/AssetAsBuiltFieldMapper.java
+++ b/tx-backend/src/main/java/org/eclipse/tractusx/traceability/assets/application/asbuilt/mapper/AssetAsBuiltFieldMapper.java
@@ -48,7 +48,10 @@ public class AssetAsBuiltFieldMapper extends BaseRequestFieldMapper {
             Map.entry("semanticDataModel", "semanticDataModel"),
             Map.entry("semanticModelId", "semanticModelId"),
             Map.entry("van", "van"),
-            Map.entry("businessPartner", "manufacturerId")
+            Map.entry("businessPartner", "manufacturerId"),
+            Map.entry("alerts", "alerts"),
+            Map.entry("qualityAlertIdsInStatusActive", "activeAlertsCount"),
+            Map.entry("qualityInvestigationIdsInStatusActive", "activeInvestigationsCount")
     );
 
     @Override

--- a/tx-backend/src/main/java/org/eclipse/tractusx/traceability/assets/application/asbuilt/mapper/AssetAsBuiltResponseMapper.java
+++ b/tx-backend/src/main/java/org/eclipse/tractusx/traceability/assets/application/asbuilt/mapper/AssetAsBuiltResponseMapper.java
@@ -54,8 +54,8 @@ public class AssetAsBuiltResponseMapper extends AssetBaseResponseMapper {
                 .van(asset.getVan())
                 .semanticDataModel(from(asset.getSemanticDataModel()))
                 .detailAspectModels(fromList(asset.getDetailAspectModels()))
-                .qualityAlertIdsInStatusActive(gettNotificationIdsInActiveState(asset.getQualityAlerts()))
-                .qualityInvestigationIdsInStatusActive(gettNotificationIdsInActiveState(asset.getQualityInvestigations()))
+                .qualityAlertIdsInStatusActive(getNotificationIdsInActiveState(asset.getQualityAlerts()))
+                .qualityInvestigationIdsInStatusActive(getNotificationIdsInActiveState(asset.getQualityInvestigations()))
                 .build();
     }
 

--- a/tx-backend/src/main/java/org/eclipse/tractusx/traceability/assets/application/asplanned/mapper/AssetAsPlannedResponseMapper.java
+++ b/tx-backend/src/main/java/org/eclipse/tractusx/traceability/assets/application/asplanned/mapper/AssetAsPlannedResponseMapper.java
@@ -54,8 +54,8 @@ public class AssetAsPlannedResponseMapper extends AssetBaseResponseMapper {
                 .van(asset.getVan())
                 .semanticDataModel(from(asset.getSemanticDataModel()))
                 .detailAspectModels(fromList(asset.getDetailAspectModels()))
-                .qualityAlertIdsInStatusActive(gettNotificationIdsInActiveState(asset.getQualityAlerts()))
-                .qualityInvestigationIdsInStatusActive(gettNotificationIdsInActiveState(asset.getQualityInvestigations()))
+                .qualityAlertIdsInStatusActive(getNotificationIdsInActiveState(asset.getQualityAlerts()))
+                .qualityInvestigationIdsInStatusActive(getNotificationIdsInActiveState(asset.getQualityInvestigations()))
                 .build();
     }
 

--- a/tx-backend/src/main/java/org/eclipse/tractusx/traceability/assets/application/base/mapper/AssetBaseResponseMapper.java
+++ b/tx-backend/src/main/java/org/eclipse/tractusx/traceability/assets/application/base/mapper/AssetBaseResponseMapper.java
@@ -135,7 +135,7 @@ public class AssetBaseResponseMapper {
         return SemanticDataModelResponse.valueOf(semanticDataModel.name());
     }
 
-    protected static List<Long> gettNotificationIdsInActiveState(List<QualityNotification> notifications) {
+    protected static List<Long> getNotificationIdsInActiveState(List<QualityNotification> notifications) {
         return emptyIfNull(notifications).stream()
                 .filter(QualityNotification::isActiveState)
                 .map(QualityNotification::getNotificationId)

--- a/tx-backend/src/main/java/org/eclipse/tractusx/traceability/assets/domain/base/AssetRepository.java
+++ b/tx-backend/src/main/java/org/eclipse/tractusx/traceability/assets/domain/base/AssetRepository.java
@@ -34,7 +34,7 @@ public interface AssetRepository {
 
     List<AssetBase> getAssetsById(List<String> assetIds);
 
-    AssetBase getAssetByChildId(String assetId, String childId);
+    AssetBase getAssetByChildId(String childId);
 
     PageResult<AssetBase> getAssets(Pageable pageable, SearchCriteria searchCriteria);
 

--- a/tx-backend/src/main/java/org/eclipse/tractusx/traceability/assets/domain/base/service/AbstractAssetBaseService.java
+++ b/tx-backend/src/main/java/org/eclipse/tractusx/traceability/assets/domain/base/service/AbstractAssetBaseService.java
@@ -143,7 +143,7 @@ public abstract class AbstractAssetBaseService implements AssetBaseService {
 
     @Override
     public AssetBase getAssetByChildId(String assetId, String childId) {
-        return getAssetRepository().getAssetByChildId(assetId, childId);
+        return getAssetRepository().getAssetByChildId(childId);
     }
 
     @Override

--- a/tx-backend/src/main/java/org/eclipse/tractusx/traceability/assets/infrastructure/asbuilt/repository/AssetAsBuildSpecification.java
+++ b/tx-backend/src/main/java/org/eclipse/tractusx/traceability/assets/infrastructure/asbuilt/repository/AssetAsBuildSpecification.java
@@ -23,11 +23,18 @@ import jakarta.persistence.criteria.CriteriaBuilder;
 import jakarta.persistence.criteria.CriteriaQuery;
 import jakarta.persistence.criteria.Predicate;
 import jakarta.persistence.criteria.Root;
+import jakarta.persistence.criteria.Subquery;
 import org.eclipse.tractusx.traceability.assets.infrastructure.asbuilt.model.AssetAsBuiltEntity;
 import org.eclipse.tractusx.traceability.common.model.SearchCriteriaFilter;
+import org.eclipse.tractusx.traceability.common.model.SearchCriteriaStrategy;
 import org.eclipse.tractusx.traceability.common.repository.BaseSpecification;
+import org.eclipse.tractusx.traceability.qualitynotification.domain.base.model.QualityNotificationStatus;
+import org.eclipse.tractusx.traceability.qualitynotification.infrastructure.alert.model.AlertEntity;
+import org.eclipse.tractusx.traceability.qualitynotification.infrastructure.investigation.model.InvestigationEntity;
 import org.jetbrains.annotations.NotNull;
 import org.springframework.data.jpa.domain.Specification;
+
+import java.util.List;
 
 
 public class AssetAsBuildSpecification extends BaseSpecification<AssetAsBuiltEntity> implements Specification<AssetAsBuiltEntity> {
@@ -37,6 +44,49 @@ public class AssetAsBuildSpecification extends BaseSpecification<AssetAsBuiltEnt
 
     @Override
     public Predicate toPredicate(@NotNull Root<AssetAsBuiltEntity> root, @NotNull CriteriaQuery<?> query, @NotNull CriteriaBuilder builder) {
+        if (SearchCriteriaStrategy.NOTIFICATION_COUNT_EQUAL.equals(getSearchCriteriaFilter().getStrategy())) {
+            return activeNotificationCountEqualPredicate(getSearchCriteriaFilter(), root, builder, getSearchCriteriaFilter().getValue());
+        }
+
         return createPredicate(getSearchCriteriaFilter(), root, builder);
+    }
+
+
+    private static Predicate activeNotificationCountEqualPredicate(SearchCriteriaFilter criteria, Root<?> root, CriteriaBuilder builder, String expectedFieldValue) {
+        String joinTableName;
+        Class<?> notificationClass;
+        switch (criteria.getKey()) {
+            case "activeAlertsCount" -> {
+                notificationClass = AlertEntity.class;
+                joinTableName = "alerts";
+            }
+            case "activeInvestigationsCount" -> {
+                notificationClass = InvestigationEntity.class;
+                joinTableName = "investigations";
+            }
+            default -> throw new UnsupportedOperationException();
+        }
+
+        CriteriaQuery<?> cq = builder.createQuery();
+
+        Subquery<Long> sub = cq.subquery(Long.class);
+        Root<?> subRoot = sub.from(notificationClass);
+        sub.select(builder.count(subRoot.get("id")));
+        sub.where(
+                builder.or(
+                        activeNotificationPredicates(builder, subRoot)
+                )
+        );
+        root.join(joinTableName);
+
+        return builder.equal(sub, Integer.parseInt(expectedFieldValue));
+    }
+
+    private static Predicate[] activeNotificationPredicates(CriteriaBuilder builder, Root<?> root) {
+        List<Predicate> predicates = QualityNotificationStatus.getActiveStates().stream()
+                .map(state -> builder.equal(root.get("status").as(String.class), state.name()))
+                .toList();
+
+        return predicates.toArray(new Predicate[0]);
     }
 }

--- a/tx-backend/src/main/java/org/eclipse/tractusx/traceability/assets/infrastructure/asbuilt/repository/AssetAsBuildSpecification.java
+++ b/tx-backend/src/main/java/org/eclipse/tractusx/traceability/assets/infrastructure/asbuilt/repository/AssetAsBuildSpecification.java
@@ -22,6 +22,7 @@ package org.eclipse.tractusx.traceability.assets.infrastructure.asbuilt.reposito
 import jakarta.persistence.criteria.CriteriaBuilder;
 import jakarta.persistence.criteria.CriteriaQuery;
 import jakarta.persistence.criteria.Join;
+import jakarta.persistence.criteria.JoinType;
 import jakarta.persistence.criteria.Predicate;
 import jakarta.persistence.criteria.Root;
 import jakarta.persistence.criteria.Subquery;
@@ -74,7 +75,7 @@ public class AssetAsBuildSpecification extends BaseSpecification<AssetAsBuiltEnt
         Root<?> subRoot = sub.from(notificationClass);
         Join<?, ?> assetJoin = subRoot.join("assets");
         sub.select(builder.count(subRoot.get("id")));
-        root.join(joinTableName);
+        root.join(joinTableName, JoinType.LEFT);
         sub.where(
                 builder.and(
                         builder.or(
@@ -83,7 +84,6 @@ public class AssetAsBuildSpecification extends BaseSpecification<AssetAsBuiltEnt
                         builder.equal(assetJoin.get("id"), root.get("id")))
 
         );
-
         return builder.equal(sub, Integer.parseInt(expectedFieldValue));
     }
 

--- a/tx-backend/src/main/java/org/eclipse/tractusx/traceability/assets/infrastructure/asbuilt/repository/AssetAsBuildSpecification.java
+++ b/tx-backend/src/main/java/org/eclipse/tractusx/traceability/assets/infrastructure/asbuilt/repository/AssetAsBuildSpecification.java
@@ -21,6 +21,7 @@ package org.eclipse.tractusx.traceability.assets.infrastructure.asbuilt.reposito
 
 import jakarta.persistence.criteria.CriteriaBuilder;
 import jakarta.persistence.criteria.CriteriaQuery;
+import jakarta.persistence.criteria.Join;
 import jakarta.persistence.criteria.Predicate;
 import jakarta.persistence.criteria.Root;
 import jakarta.persistence.criteria.Subquery;
@@ -71,13 +72,17 @@ public class AssetAsBuildSpecification extends BaseSpecification<AssetAsBuiltEnt
 
         Subquery<Long> sub = cq.subquery(Long.class);
         Root<?> subRoot = sub.from(notificationClass);
+        Join<?, ?> assetJoin = subRoot.join("assets");
         sub.select(builder.count(subRoot.get("id")));
-        sub.where(
-                builder.or(
-                        activeNotificationPredicates(builder, subRoot)
-                )
-        );
         root.join(joinTableName);
+        sub.where(
+                builder.and(
+                        builder.or(
+                                activeNotificationPredicates(builder, subRoot)
+                        ),
+                        builder.equal(assetJoin.get("id"), root.get("id")))
+
+        );
 
         return builder.equal(sub, Integer.parseInt(expectedFieldValue));
     }

--- a/tx-backend/src/main/java/org/eclipse/tractusx/traceability/assets/infrastructure/asbuilt/repository/AssetAsBuiltRepositoryImpl.java
+++ b/tx-backend/src/main/java/org/eclipse/tractusx/traceability/assets/infrastructure/asbuilt/repository/AssetAsBuiltRepositoryImpl.java
@@ -72,7 +72,7 @@ public class AssetAsBuiltRepositoryImpl implements AssetAsBuiltRepository {
     }
 
     @Override
-    public AssetBase getAssetByChildId(String assetId, String childId) {
+    public AssetBase getAssetByChildId(String childId) {
         return jpaAssetAsBuiltRepository.findById(childId)
                 .map(AssetAsBuiltEntity::toDomain)
                 .orElseThrow(() -> new AssetNotFoundException("Child Asset Not Found"));

--- a/tx-backend/src/main/java/org/eclipse/tractusx/traceability/assets/infrastructure/asplanned/repository/AssetAsPlannedRepositoryImpl.java
+++ b/tx-backend/src/main/java/org/eclipse/tractusx/traceability/assets/infrastructure/asplanned/repository/AssetAsPlannedRepositoryImpl.java
@@ -68,7 +68,7 @@ public class AssetAsPlannedRepositoryImpl implements AssetAsPlannedRepository {
     }
 
     @Override
-    public AssetBase getAssetByChildId(String assetId, String childId) {
+    public AssetBase getAssetByChildId(String childId) {
         return jpaAssetAsPlannedRepository.findById(childId).map(AssetAsPlannedEntity::toDomain)
                 .orElseThrow(() -> new AssetNotFoundException("Child Asset Not Found"));
     }

--- a/tx-backend/src/main/java/org/eclipse/tractusx/traceability/common/config/SecurityConfig.java
+++ b/tx-backend/src/main/java/org/eclipse/tractusx/traceability/common/config/SecurityConfig.java
@@ -26,8 +26,10 @@ import org.eclipse.tractusx.traceability.common.security.JwtAuthenticationTokenC
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
@@ -67,12 +69,12 @@ public class SecurityConfig {
     @Bean
     SecurityFilterChain securityFilterChain(final HttpSecurity httpSecurity) throws Exception {
 
-        httpSecurity.httpBasic().disable();
-        httpSecurity.formLogin().disable();
-        httpSecurity.logout().disable();
-        httpSecurity.anonymous().disable();
-        httpSecurity.csrf().disable();
-        httpSecurity.cors();
+        httpSecurity.httpBasic(AbstractHttpConfigurer::disable);
+        httpSecurity.formLogin(AbstractHttpConfigurer::disable);
+        httpSecurity.logout(AbstractHttpConfigurer::disable);
+        httpSecurity.anonymous(AbstractHttpConfigurer::disable);
+        httpSecurity.csrf(AbstractHttpConfigurer::disable);
+        httpSecurity.cors(Customizer.withDefaults());
 
 
         httpSecurity.authorizeHttpRequests(auth -> auth
@@ -81,10 +83,10 @@ public class SecurityConfig {
                 .anyRequest()
                 .authenticated());
 
-        httpSecurity.oauth2ResourceServer(oauth2ResourceServer -> oauth2ResourceServer.jwt()
-                        .jwtAuthenticationConverter(
-                                new JwtAuthenticationTokenConverter(resourceClient)))
-                .oauth2Client();
+        httpSecurity.oauth2ResourceServer(oauth2ResourceServer -> oauth2ResourceServer.jwt((jwt) -> jwt.jwtAuthenticationConverter(
+                        new JwtAuthenticationTokenConverter(resourceClient)))
+                )
+                .oauth2Client(Customizer.withDefaults());
 
         return httpSecurity.build();
     }

--- a/tx-backend/src/main/java/org/eclipse/tractusx/traceability/common/model/SearchCriteriaStrategy.java
+++ b/tx-backend/src/main/java/org/eclipse/tractusx/traceability/common/model/SearchCriteriaStrategy.java
@@ -24,5 +24,6 @@ public enum SearchCriteriaStrategy {
     STARTS_WITH,
     AT_LOCAL_DATE,
     AFTER_LOCAL_DATE,
-    BEFORE_LOCAL_DATE
+    BEFORE_LOCAL_DATE,
+    NOTIFICATION_COUNT_EQUAL
 }

--- a/tx-backend/src/main/java/org/eclipse/tractusx/traceability/common/repository/BaseSpecification.java
+++ b/tx-backend/src/main/java/org/eclipse/tractusx/traceability/common/repository/BaseSpecification.java
@@ -53,9 +53,9 @@ public abstract class BaseSpecification<T> implements Specification<T> {
     }
 
     protected Predicate createPredicate(SearchCriteriaFilter criteria, Root<?> root, CriteriaBuilder builder) {
+        String expectedFieldValue = criteria.getValue();
         String fieldName = getJoinTableFieldName(criteria.getKey());
         Path<Object> fieldPath = getFieldPath(root, criteria);
-        String expectedFieldValue = criteria.getValue();
 
         if (SearchCriteriaStrategy.EQUAL.equals(criteria.getStrategy())) {
             return builder.equal(
@@ -88,6 +88,7 @@ public abstract class BaseSpecification<T> implements Specification<T> {
             return builder.greaterThanOrEqualTo(fieldPath.as(LocalDateTime.class),
                     LocalDateTime.of(localDate, LocalTime.MIN));
         }
+
         return null;
     }
 

--- a/tx-backend/src/main/java/org/eclipse/tractusx/traceability/qualitynotification/application/base/mapper/QualityNotificationFieldMapper.java
+++ b/tx-backend/src/main/java/org/eclipse/tractusx/traceability/qualitynotification/application/base/mapper/QualityNotificationFieldMapper.java
@@ -43,7 +43,8 @@ public class QualityNotificationFieldMapper extends BaseRequestFieldMapper {
             Map.entry("createdByName", "notifications_createdByName"),
             Map.entry("sendTo", "notifications_sentTo"),
             Map.entry("sendToName", "notifications_sentToName"),
-            Map.entry("targetDate", "notifications_targetDate")
+            Map.entry("targetDate", "notifications_targetDate"),
+            Map.entry("assetId", "assets_id")
 
     );
 

--- a/tx-backend/src/main/java/org/eclipse/tractusx/traceability/qualitynotification/domain/base/model/QualityNotificationStatus.java
+++ b/tx-backend/src/main/java/org/eclipse/tractusx/traceability/qualitynotification/domain/base/model/QualityNotificationStatus.java
@@ -99,6 +99,10 @@ public enum QualityNotificationStatus {
         return ACTIVE_STATES.contains(this);
     }
 
+    public static List<QualityNotificationStatus> getActiveStates() {
+        return ACTIVE_STATES;
+    }
+
     public static QualityNotificationStatus from(QualityNotificationStatusRequest qualityNotificationStatusRequest) {
         return QualityNotificationStatus.fromStringValue(qualityNotificationStatusRequest.name());
     }

--- a/tx-backend/src/main/java/org/eclipse/tractusx/traceability/qualitynotification/infrastructure/alert/model/AlertEntity.java
+++ b/tx-backend/src/main/java/org/eclipse/tractusx/traceability/qualitynotification/infrastructure/alert/model/AlertEntity.java
@@ -60,7 +60,7 @@ public class AlertEntity extends NotificationBaseEntity {
             joinColumns = @JoinColumn(name = "alert_id"),
             inverseJoinColumns = @JoinColumn(name = "asset_id")
     )
-    private List<AssetAsBuiltEntity> assets;
+    public List<AssetAsBuiltEntity> assets;
 
     @ManyToMany(cascade = CascadeType.ALL)
     @JoinTable(

--- a/tx-backend/src/test/java/org/eclipse/tractusx/traceability/assets/infrastructure/repository/jpa/PersistentAssetsAsBuiltRepositoryTest.java
+++ b/tx-backend/src/test/java/org/eclipse/tractusx/traceability/assets/infrastructure/repository/jpa/PersistentAssetsAsBuiltRepositoryTest.java
@@ -23,14 +23,10 @@ import org.eclipse.tractusx.traceability.assets.domain.base.model.AssetBase;
 import org.eclipse.tractusx.traceability.assets.domain.base.model.Owner;
 import org.eclipse.tractusx.traceability.assets.domain.base.model.QualityType;
 import org.eclipse.tractusx.traceability.assets.infrastructure.asbuilt.model.AssetAsBuiltEntity;
-import org.eclipse.tractusx.traceability.assets.infrastructure.asbuilt.repository.AssetAsBuiltRepositoryImpl;
-import org.eclipse.tractusx.traceability.assets.infrastructure.asbuilt.repository.JpaAssetAsBuiltRepository;
 import org.eclipse.tractusx.traceability.assets.infrastructure.base.model.SemanticDataModelEntity;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.time.Instant;
@@ -41,22 +37,17 @@ import static org.eclipse.tractusx.traceability.testdata.AssetTestDataFactory.cr
 @ExtendWith(MockitoExtension.class)
 class PersistentAssetsAsBuiltRepositoryTest {
 
-    @InjectMocks
-    private AssetAsBuiltRepositoryImpl persistentAssetsRepository;
-
-    @Mock
-    private JpaAssetAsBuiltRepository jpaAssetsRepository;
 
     @Test
     void testToAsset() {
         // Given
         AssetAsBuiltEntity entity = AssetAsBuiltEntity.builder()
-                .id("1")
-                .idShort("1234")
+                .id("urn:uuid:0733946c-59c6-41ae-9570-cb43a6e4eb01")
+                .idShort("a/devNTierAPlastics")
                 .nameAtManufacturer("Manufacturer Name")
                 .manufacturerPartId("customer123")
                 .semanticModelId("PI001")
-                .manufacturerId("manuId")
+                .manufacturerId("BPNL00000003CML1")
                 .manufacturerName("manuName")
                 .nameAtCustomer("Customer Name")
                 .customerPartId("customerPartId")
@@ -65,7 +56,7 @@ class PersistentAssetsAsBuiltRepositoryTest {
                 .semanticDataModel(SemanticDataModelEntity.SERIALPART)
                 .owner(Owner.OWN)
                 .qualityType(QualityType.CRITICAL)
-                .van("van123")
+                .van("OMAOYGBDTSRCMYSCX")
                 .childDescriptors(List.of(AssetAsBuiltEntity.ChildDescription.builder()
                                 .id("child1")
                                 .idShort("desc1")

--- a/tx-backend/src/test/java/org/eclipse/tractusx/traceability/integration/assets/AssetAsBuiltControllerFilteringIT.java
+++ b/tx-backend/src/test/java/org/eclipse/tractusx/traceability/integration/assets/AssetAsBuiltControllerFilteringIT.java
@@ -462,4 +462,102 @@ class AssetAsBuiltControllerFilteringIT extends IntegrationTestSpecification {
                 .assertThat()
                 .body("totalItems", equalTo(1));
     }
+
+    @Test
+    void givenAssetsWithInvestigations_whenGetAssetsWithActiveInvestigationCountFilter3_thenReturnProperAssets() throws JoseException {
+        // Given
+        assetsSupport.defaultAssetsStored();
+        AssetAsBuiltEntity assetAsBuilt = jpaAssetAsBuiltRepository.findById("urn:uuid:d387fa8e-603c-42bd-98c3-4d87fef8d2bb").orElseThrow();
+        AssetAsBuiltEntity assetAsBuilt1 = jpaAssetAsBuiltRepository.findById("urn:uuid:7fa65f10-9dc1-49fe-818a-09c7313a4562").orElseThrow();
+        investigationsSupport.storeInvestigationWithStatusAndAssets(CREATED, List.of(assetAsBuilt, assetAsBuilt1), null);
+        investigationsSupport.storeInvestigationWithStatusAndAssets(SENT, List.of(assetAsBuilt1), null);
+        investigationsSupport.storeInvestigationWithStatusAndAssets(SENT, List.of(assetAsBuilt), null);
+        investigationsSupport.storeInvestigationWithStatusAndAssets(RECEIVED, List.of(assetAsBuilt), null);
+        investigationsSupport.storeInvestigationWithStatusAndAssets(ACKNOWLEDGED, List.of(assetAsBuilt), null);
+        investigationsSupport.storeInvestigationWithStatusAndAssets(ACCEPTED, List.of(assetAsBuilt), null);
+        investigationsSupport.storeInvestigationWithStatusAndAssets(DECLINED, List.of(assetAsBuilt), null);
+        investigationsSupport.storeInvestigationWithStatusAndAssets(CANCELED, List.of(assetAsBuilt), null);
+        investigationsSupport.storeInvestigationWithStatusAndAssets(CLOSED, List.of(assetAsBuilt), null);
+
+        final String filter = "qualityInvestigationIdsInStatusActive,NOTIFICATION_COUNT_EQUAL,0,AND";
+
+
+        // When
+        given()
+                .header(oAuth2Support.jwtAuthorization(ADMIN))
+                .contentType(ContentType.JSON)
+                .when()
+                .param("filter", filter)
+                .get("/api/assets/as-built")
+                .then()
+                .statusCode(200)
+                .assertThat()
+                .body("totalItems", equalTo(11));
+    }
+
+    @Test
+    void givenAssetsWithInvestigations_whenGetAssetsWithActiveInvestigationCountFilter4_thenReturnProperAssets() throws JoseException {
+        // Given
+        assetsSupport.defaultAssetsStored();
+        AssetAsBuiltEntity assetAsBuilt = jpaAssetAsBuiltRepository.findById("urn:uuid:d387fa8e-603c-42bd-98c3-4d87fef8d2bb").orElseThrow();
+        AssetAsBuiltEntity assetAsBuilt1 = jpaAssetAsBuiltRepository.findById("urn:uuid:7fa65f10-9dc1-49fe-818a-09c7313a4562").orElseThrow();
+        investigationsSupport.storeInvestigationWithStatusAndAssets(CREATED, List.of(assetAsBuilt, assetAsBuilt1), null);
+        investigationsSupport.storeInvestigationWithStatusAndAssets(SENT, List.of(assetAsBuilt1), null);
+        investigationsSupport.storeInvestigationWithStatusAndAssets(SENT, List.of(assetAsBuilt), null);
+        investigationsSupport.storeInvestigationWithStatusAndAssets(RECEIVED, List.of(assetAsBuilt), null);
+        investigationsSupport.storeInvestigationWithStatusAndAssets(ACKNOWLEDGED, List.of(assetAsBuilt), null);
+        investigationsSupport.storeInvestigationWithStatusAndAssets(ACCEPTED, List.of(assetAsBuilt), null);
+        investigationsSupport.storeInvestigationWithStatusAndAssets(DECLINED, List.of(assetAsBuilt), null);
+        investigationsSupport.storeInvestigationWithStatusAndAssets(CANCELED, List.of(assetAsBuilt), null);
+        investigationsSupport.storeInvestigationWithStatusAndAssets(CLOSED, List.of(assetAsBuilt), null);
+
+        final String filter = "qualityAlertIdsInStatusActive,NOTIFICATION_COUNT_EQUAL,0,AND";
+
+
+        // When
+        given()
+                .header(oAuth2Support.jwtAuthorization(ADMIN))
+                .contentType(ContentType.JSON)
+                .when()
+                .param("filter", filter)
+                .get("/api/assets/as-built")
+                .then()
+                .statusCode(200)
+                .assertThat()
+                .body("totalItems", equalTo(13));
+    }
+
+    @Test
+    void givenAssetsWithInvestigations_whenGetAssetsWithActiveInvestigationCountFilter5_thenReturnProperAssets() throws JoseException {
+        // Given
+        assetsSupport.defaultAssetsStored();
+        AssetAsBuiltEntity assetAsBuilt = jpaAssetAsBuiltRepository.findById("urn:uuid:d387fa8e-603c-42bd-98c3-4d87fef8d2bb").orElseThrow();
+        AssetAsBuiltEntity assetAsBuilt1 = jpaAssetAsBuiltRepository.findById("urn:uuid:7fa65f10-9dc1-49fe-818a-09c7313a4562").orElseThrow();
+        investigationsSupport.storeInvestigationWithStatusAndAssets(CREATED, List.of(assetAsBuilt, assetAsBuilt1), null);
+        investigationsSupport.storeInvestigationWithStatusAndAssets(SENT, List.of(assetAsBuilt1), null);
+        investigationsSupport.storeInvestigationWithStatusAndAssets(SENT, List.of(assetAsBuilt), null);
+        investigationsSupport.storeInvestigationWithStatusAndAssets(RECEIVED, List.of(assetAsBuilt), null);
+        investigationsSupport.storeInvestigationWithStatusAndAssets(ACKNOWLEDGED, List.of(assetAsBuilt), null);
+        investigationsSupport.storeInvestigationWithStatusAndAssets(ACCEPTED, List.of(assetAsBuilt), null);
+        investigationsSupport.storeInvestigationWithStatusAndAssets(DECLINED, List.of(assetAsBuilt), null);
+        investigationsSupport.storeInvestigationWithStatusAndAssets(CANCELED, List.of(assetAsBuilt), null);
+        investigationsSupport.storeInvestigationWithStatusAndAssets(CLOSED, List.of(assetAsBuilt), null);
+
+        final String filter1 = "qualityAlertIdsInStatusActive,NOTIFICATION_COUNT_EQUAL,0,AND";
+        final String filter2 = "qualityInvestigationIdsInStatusActive,NOTIFICATION_COUNT_EQUAL,2,AND";
+
+
+        // When
+        given()
+                .header(oAuth2Support.jwtAuthorization(ADMIN))
+                .contentType(ContentType.JSON)
+                .when()
+                .param("filter", filter1)
+                .param("filter", filter2)
+                .get("/api/assets/as-built")
+                .then()
+                .statusCode(200)
+                .assertThat()
+                .body("totalItems", equalTo(1));
+    }
 }

--- a/tx-backend/src/test/java/org/eclipse/tractusx/traceability/integration/assets/AssetAsBuiltControllerFilteringIT.java
+++ b/tx-backend/src/test/java/org/eclipse/tractusx/traceability/integration/assets/AssetAsBuiltControllerFilteringIT.java
@@ -43,7 +43,6 @@ import static org.eclipse.tractusx.traceability.qualitynotification.infrastructu
 import static org.eclipse.tractusx.traceability.qualitynotification.infrastructure.model.NotificationStatusBaseEntity.RECEIVED;
 import static org.eclipse.tractusx.traceability.qualitynotification.infrastructure.model.NotificationStatusBaseEntity.SENT;
 import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.hasSize;
 
 class AssetAsBuiltControllerFilteringIT extends IntegrationTestSpecification {
 
@@ -371,6 +370,38 @@ class AssetAsBuiltControllerFilteringIT extends IntegrationTestSpecification {
     }
 
     @Test
+    void givenAssetsWithAlerts_whenGetAssetsWithActiveAlertCountFilter2_thenReturnProperAssets() throws JoseException {
+        // Given
+        assetsSupport.defaultAssetsStored();
+        AssetAsBuiltEntity assetAsBuilt = jpaAssetAsBuiltRepository.findById("urn:uuid:d387fa8e-603c-42bd-98c3-4d87fef8d2bb").orElseThrow();
+        AssetAsBuiltEntity assetAsBuilt1 = jpaAssetAsBuiltRepository.findById("urn:uuid:7fa65f10-9dc1-49fe-818a-09c7313a4562").orElseThrow();
+        alertsSupport.storeAlertWithStatusAndAssets(CREATED, List.of(assetAsBuilt, assetAsBuilt1), null);
+        alertsSupport.storeAlertWithStatusAndAssets(SENT, List.of(assetAsBuilt1), null);
+        alertsSupport.storeAlertWithStatusAndAssets(SENT, List.of(assetAsBuilt), null);
+        alertsSupport.storeAlertWithStatusAndAssets(RECEIVED, List.of(assetAsBuilt), null);
+        alertsSupport.storeAlertWithStatusAndAssets(ACKNOWLEDGED, List.of(assetAsBuilt), null);
+        alertsSupport.storeAlertWithStatusAndAssets(ACCEPTED, List.of(assetAsBuilt), null);
+        alertsSupport.storeAlertWithStatusAndAssets(DECLINED, List.of(assetAsBuilt), null);
+        alertsSupport.storeAlertWithStatusAndAssets(CANCELED, List.of(assetAsBuilt), null);
+        alertsSupport.storeAlertWithStatusAndAssets(CLOSED, List.of(assetAsBuilt), null);
+
+        final String filter = "qualityAlertIdsInStatusActive,NOTIFICATION_COUNT_EQUAL,2,AND";
+
+        // When
+        given()
+                .header(oAuth2Support.jwtAuthorization(ADMIN))
+                .contentType(ContentType.JSON)
+                .when()
+                .param("filter", filter)
+                .get("/api/assets/as-built")
+                .then()
+                .log().all()
+                .statusCode(200)
+                .assertThat()
+                .body("totalItems", equalTo(1));
+    }
+
+    @Test
     void givenAssetsWithInvestigations_whenGetAssetsWithActiveInvestigationCountFilter_thenReturnProperAssets() throws JoseException {
         // Given
         assetsSupport.defaultAssetsStored();
@@ -385,6 +416,38 @@ class AssetAsBuiltControllerFilteringIT extends IntegrationTestSpecification {
         investigationsSupport.storeInvestigationWithStatusAndAssets(CLOSED, List.of(assetAsBuilt), null);
 
         final String filter = "qualityInvestigationIdsInStatusActive,NOTIFICATION_COUNT_EQUAL,6,AND";
+
+
+        // When
+        given()
+                .header(oAuth2Support.jwtAuthorization(ADMIN))
+                .contentType(ContentType.JSON)
+                .when()
+                .param("filter", filter)
+                .get("/api/assets/as-built")
+                .then()
+                .statusCode(200)
+                .assertThat()
+                .body("totalItems", equalTo(1));
+    }
+
+    @Test
+    void givenAssetsWithInvestigations_whenGetAssetsWithActiveInvestigationCountFilter2_thenReturnProperAssets() throws JoseException {
+        // Given
+        assetsSupport.defaultAssetsStored();
+        AssetAsBuiltEntity assetAsBuilt = jpaAssetAsBuiltRepository.findById("urn:uuid:d387fa8e-603c-42bd-98c3-4d87fef8d2bb").orElseThrow();
+        AssetAsBuiltEntity assetAsBuilt1 = jpaAssetAsBuiltRepository.findById("urn:uuid:7fa65f10-9dc1-49fe-818a-09c7313a4562").orElseThrow();
+        investigationsSupport.storeInvestigationWithStatusAndAssets(CREATED, List.of(assetAsBuilt, assetAsBuilt1), null);
+        investigationsSupport.storeInvestigationWithStatusAndAssets(SENT, List.of(assetAsBuilt1), null);
+        investigationsSupport.storeInvestigationWithStatusAndAssets(SENT, List.of(assetAsBuilt), null);
+        investigationsSupport.storeInvestigationWithStatusAndAssets(RECEIVED, List.of(assetAsBuilt), null);
+        investigationsSupport.storeInvestigationWithStatusAndAssets(ACKNOWLEDGED, List.of(assetAsBuilt), null);
+        investigationsSupport.storeInvestigationWithStatusAndAssets(ACCEPTED, List.of(assetAsBuilt), null);
+        investigationsSupport.storeInvestigationWithStatusAndAssets(DECLINED, List.of(assetAsBuilt), null);
+        investigationsSupport.storeInvestigationWithStatusAndAssets(CANCELED, List.of(assetAsBuilt), null);
+        investigationsSupport.storeInvestigationWithStatusAndAssets(CLOSED, List.of(assetAsBuilt), null);
+
+        final String filter = "qualityInvestigationIdsInStatusActive,NOTIFICATION_COUNT_EQUAL,2,AND";
 
 
         // When

--- a/tx-backend/src/test/java/org/eclipse/tractusx/traceability/integration/assets/AssetAsBuiltControllerFilteringIT.java
+++ b/tx-backend/src/test/java/org/eclipse/tractusx/traceability/integration/assets/AssetAsBuiltControllerFilteringIT.java
@@ -20,16 +20,30 @@
 package org.eclipse.tractusx.traceability.integration.assets;
 
 import io.restassured.http.ContentType;
+import org.eclipse.tractusx.traceability.assets.infrastructure.asbuilt.model.AssetAsBuiltEntity;
 import org.eclipse.tractusx.traceability.assets.infrastructure.asbuilt.repository.JpaAssetAsBuiltRepository;
 import org.eclipse.tractusx.traceability.integration.IntegrationTestSpecification;
+import org.eclipse.tractusx.traceability.integration.common.support.AlertsSupport;
 import org.eclipse.tractusx.traceability.integration.common.support.AssetsSupport;
+import org.eclipse.tractusx.traceability.integration.common.support.InvestigationsSupport;
 import org.jose4j.lang.JoseException;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
+import java.util.List;
+
 import static io.restassured.RestAssured.given;
 import static org.eclipse.tractusx.traceability.common.security.JwtRole.ADMIN;
+import static org.eclipse.tractusx.traceability.qualitynotification.infrastructure.model.NotificationStatusBaseEntity.ACCEPTED;
+import static org.eclipse.tractusx.traceability.qualitynotification.infrastructure.model.NotificationStatusBaseEntity.ACKNOWLEDGED;
+import static org.eclipse.tractusx.traceability.qualitynotification.infrastructure.model.NotificationStatusBaseEntity.CANCELED;
+import static org.eclipse.tractusx.traceability.qualitynotification.infrastructure.model.NotificationStatusBaseEntity.CLOSED;
+import static org.eclipse.tractusx.traceability.qualitynotification.infrastructure.model.NotificationStatusBaseEntity.CREATED;
+import static org.eclipse.tractusx.traceability.qualitynotification.infrastructure.model.NotificationStatusBaseEntity.DECLINED;
+import static org.eclipse.tractusx.traceability.qualitynotification.infrastructure.model.NotificationStatusBaseEntity.RECEIVED;
+import static org.eclipse.tractusx.traceability.qualitynotification.infrastructure.model.NotificationStatusBaseEntity.SENT;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
 
 class AssetAsBuiltControllerFilteringIT extends IntegrationTestSpecification {
 
@@ -37,7 +51,13 @@ class AssetAsBuiltControllerFilteringIT extends IntegrationTestSpecification {
     AssetsSupport assetsSupport;
 
     @Autowired
-    JpaAssetAsBuiltRepository repo;
+    JpaAssetAsBuiltRepository jpaAssetAsBuiltRepository;
+
+    @Autowired
+    AlertsSupport alertsSupport;
+
+    @Autowired
+    InvestigationsSupport investigationsSupport;
 
     @Test
     void givenNoFilter_whenCallFilteredEndpoint_thenReturnExpectedResult() throws JoseException {
@@ -318,5 +338,65 @@ class AssetAsBuiltControllerFilteringIT extends IntegrationTestSpecification {
                 .then()
                 .log().all()
                 .statusCode(400);
+    }
+
+    @Test
+    void givenAssetsWithAlerts_whenGetAssetsWithActiveAlertCountFilter_thenReturnProperAssets() throws JoseException {
+        // Given
+        assetsSupport.defaultAssetsStored();
+        AssetAsBuiltEntity assetAsBuilt = jpaAssetAsBuiltRepository.findById("urn:uuid:d387fa8e-603c-42bd-98c3-4d87fef8d2bb").orElseThrow();
+        alertsSupport.storeAlertWithStatusAndAssets(CREATED, List.of(assetAsBuilt), null);
+        alertsSupport.storeAlertWithStatusAndAssets(SENT, List.of(assetAsBuilt), null);
+        alertsSupport.storeAlertWithStatusAndAssets(RECEIVED, List.of(assetAsBuilt), null);
+        alertsSupport.storeAlertWithStatusAndAssets(ACKNOWLEDGED, List.of(assetAsBuilt), null);
+        alertsSupport.storeAlertWithStatusAndAssets(ACCEPTED, List.of(assetAsBuilt), null);
+        alertsSupport.storeAlertWithStatusAndAssets(DECLINED, List.of(assetAsBuilt), null);
+        alertsSupport.storeAlertWithStatusAndAssets(CANCELED, List.of(assetAsBuilt), null);
+        alertsSupport.storeAlertWithStatusAndAssets(CLOSED, List.of(assetAsBuilt), null);
+
+        final String filter = "qualityAlertIdsInStatusActive,NOTIFICATION_COUNT_EQUAL,6,AND";
+
+        // When
+        given()
+                .header(oAuth2Support.jwtAuthorization(ADMIN))
+                .contentType(ContentType.JSON)
+                .when()
+                .param("filter", filter)
+                .get("/api/assets/as-built")
+                .then()
+                .log().all()
+                .statusCode(200)
+                .assertThat()
+                .body("totalItems", equalTo(1));
+    }
+
+    @Test
+    void givenAssetsWithInvestigations_whenGetAssetsWithActiveInvestigationCountFilter_thenReturnProperAssets() throws JoseException {
+        // Given
+        assetsSupport.defaultAssetsStored();
+        AssetAsBuiltEntity assetAsBuilt = jpaAssetAsBuiltRepository.findById("urn:uuid:d387fa8e-603c-42bd-98c3-4d87fef8d2bb").orElseThrow();
+        investigationsSupport.storeInvestigationWithStatusAndAssets(CREATED, List.of(assetAsBuilt), null);
+        investigationsSupport.storeInvestigationWithStatusAndAssets(SENT, List.of(assetAsBuilt), null);
+        investigationsSupport.storeInvestigationWithStatusAndAssets(RECEIVED, List.of(assetAsBuilt), null);
+        investigationsSupport.storeInvestigationWithStatusAndAssets(ACKNOWLEDGED, List.of(assetAsBuilt), null);
+        investigationsSupport.storeInvestigationWithStatusAndAssets(ACCEPTED, List.of(assetAsBuilt), null);
+        investigationsSupport.storeInvestigationWithStatusAndAssets(DECLINED, List.of(assetAsBuilt), null);
+        investigationsSupport.storeInvestigationWithStatusAndAssets(CANCELED, List.of(assetAsBuilt), null);
+        investigationsSupport.storeInvestigationWithStatusAndAssets(CLOSED, List.of(assetAsBuilt), null);
+
+        final String filter = "qualityInvestigationIdsInStatusActive,NOTIFICATION_COUNT_EQUAL,6,AND";
+
+
+        // When
+        given()
+                .header(oAuth2Support.jwtAuthorization(ADMIN))
+                .contentType(ContentType.JSON)
+                .when()
+                .param("filter", filter)
+                .get("/api/assets/as-built")
+                .then()
+                .statusCode(200)
+                .assertThat()
+                .body("totalItems", equalTo(1));
     }
 }

--- a/tx-backend/src/test/java/org/eclipse/tractusx/traceability/testdata/AssetTestDataFactory.java
+++ b/tx-backend/src/test/java/org/eclipse/tractusx/traceability/testdata/AssetTestDataFactory.java
@@ -19,8 +19,13 @@
 
 package org.eclipse.tractusx.traceability.testdata;
 
+import org.eclipse.tractusx.traceability.assets.domain.asbuilt.model.aspect.DetailAspectDataAsBuilt;
 import org.eclipse.tractusx.traceability.assets.domain.base.model.*;
+import org.eclipse.tractusx.traceability.assets.domain.base.model.aspect.DetailAspectModel;
+import org.eclipse.tractusx.traceability.assets.domain.base.model.aspect.DetailAspectType;
 
+import java.time.OffsetDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -36,43 +41,53 @@ public class AssetTestDataFactory {
 
     public static AssetBase createAssetTestData() {
 
-// TODO add detailAspectModels
 
-        return AssetBase.builder()
-                .id("1")
-                .idShort("1234")
-                .semanticModelId("456")
-                .semanticDataModel(SemanticDataModel.SERIALPART)
-                .activeAlert(false)
-                .parentRelations(AssetTestDataFactory.provideParentRelations())
-                .childRelations(AssetTestDataFactory.provideChildRelations())
-                .van("van123")
-                .qualityType(QualityType.CRITICAL)
-                .inInvestigation(false)
-                .owner(Owner.OWN)
-                .manufacturerName("manuName")
-                .manufacturerId("manuId")
+        DetailAspectDataAsBuilt detailAspectDataAsBuilt = DetailAspectDataAsBuilt.builder()
+                .partId("1")
+                .customerPartId("2")
+                .nameAtCustomer("Moritz")
+                .manufacturingCountry("Germany")
+                .manufacturingDate(OffsetDateTime.parse("2022-10-20T00:00:00Z", DateTimeFormatter.ISO_OFFSET_DATE_TIME))
                 .build();
-    }
 
-    public static AssetBase createAssetParentTestData() {
+        DetailAspectModel detailAspectModel =  DetailAspectModel.builder()
+                .data(detailAspectDataAsBuilt)
+                .type(DetailAspectType.AS_BUILT)
+                .build();
 
-// TODO add detailAspectModels
+        DetailAspectDataAsBuilt detailAspectDataAsBuilt2 = DetailAspectDataAsBuilt.builder()
+                .partId("2")
+                .customerPartId("3")
+                .nameAtCustomer("Max")
+                .manufacturingCountry("Germany")
+                .manufacturingDate(OffsetDateTime.parse("2022-10-20T00:00:00Z", DateTimeFormatter.ISO_OFFSET_DATE_TIME))
+                .build();
+
+        DetailAspectModel detailAspectModel2 =  DetailAspectModel.builder()
+                .data(detailAspectDataAsBuilt2)
+                .type(DetailAspectType.AS_BUILT)
+                .build();
+
+
+        ArrayList<DetailAspectModel> detailAspectModels = new ArrayList<>();
+        detailAspectModels.add(detailAspectModel);
+        detailAspectModels.add(detailAspectModel2);
 
         return AssetBase.builder()
-                .id("2")
-                .idShort("23456")
+                .id("urn:uuid:0733946c-59c6-41ae-9570-cb43a6e4eb01")
+                .idShort("a/devNTierAPlastics")
                 .semanticModelId("456")
                 .semanticDataModel(SemanticDataModel.SERIALPART)
                 .activeAlert(false)
                 .parentRelations(AssetTestDataFactory.provideParentRelations())
                 .childRelations(AssetTestDataFactory.provideChildRelations())
-                .van("van123")
+                .van("OMAOYGBDTSRCMYSCX")
                 .qualityType(QualityType.CRITICAL)
                 .inInvestigation(false)
                 .owner(Owner.OWN)
                 .manufacturerName("manuName")
-                .manufacturerId("manuId")
+                .manufacturerId("BPNL00000003CML1")
+                .detailAspectModels(detailAspectModels)
                 .build();
     }
 

--- a/tx-models/src/main/java/assets/response/asbuilt/DetailAspectDataAsBuiltResponse.java
+++ b/tx-models/src/main/java/assets/response/asbuilt/DetailAspectDataAsBuiltResponse.java
@@ -1,3 +1,22 @@
+/********************************************************************************
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
 package assets.response.asbuilt;
 
 import assets.response.base.DetailAspectDataResponse;

--- a/tx-models/src/main/java/assets/response/asplanned/DetailAspectDataAsPlannedResponse.java
+++ b/tx-models/src/main/java/assets/response/asplanned/DetailAspectDataAsPlannedResponse.java
@@ -1,3 +1,21 @@
+/********************************************************************************
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
 package assets.response.asplanned;
 
 import assets.response.base.DetailAspectDataResponse;

--- a/tx-models/src/main/java/assets/response/asplanned/PartSiteInformationAsPlannedResponse.java
+++ b/tx-models/src/main/java/assets/response/asplanned/PartSiteInformationAsPlannedResponse.java
@@ -1,3 +1,21 @@
+/********************************************************************************
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
 package assets.response.asplanned;
 
 import assets.response.base.DetailAspectDataResponse;

--- a/tx-models/src/main/java/bpn/request/BpnMappingRequest.java
+++ b/tx-models/src/main/java/bpn/request/BpnMappingRequest.java
@@ -1,3 +1,22 @@
+/********************************************************************************
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
 package bpn.request;
 
 import io.swagger.annotations.ApiModelProperty;


### PR DESCRIPTION
## Added
- New job named 'print_environment' to the Argo-workflow that prints the selected environment to the GitHub Step Summary.

## Changed
- Reconfigured all docker images user settings
- Adapted memory / cpu requests and limits in default values helm file
- Migrate to not deprecated methods in HTTP security
- Bump actions/setup-node@ from v3 to v4
- Bump helm/chart-releaser-action from v1.5.0 to v1.6.0
- Bump aquasecurity/trivy-action from 0.12.0 to 0.14.0
- Bump cypress-io/github-action from v6.5.0 to v6.6.0
- Bump spring-core version from 6.0.12 to 6.0.13
- Bump compiler-plugin version 3.10.1 to 3.11.0
- Bump commons-io version 2.13.0 to 2.15.0