### PR TITLE
Added separation of autocomplete mechanism selected/searched elements

### DIFF
--- a/.github/workflows/argo.yml
+++ b/.github/workflows/argo.yml
@@ -40,9 +40,6 @@ on:
       argo_token:
         description: Argo Token
         required: true
-      api_token:
-        description: Api Token
-        required: true
 
 env:
     ARGO_TEST_REGISTRY: "https://argo.dev.demo.catena-x.net/api/v1/applications/tracex-dt-registry-test"
@@ -293,39 +290,33 @@ jobs:
     needs: test_state
     runs-on: ubuntu-latest
     steps:
-
+    
      - name: Checkout code
        uses: actions/checkout@v4
-
+            
      - name: Set up Python
        uses: actions/setup-python@v4
        with:
         python-version: '3.11'
-
-     - name: mask token
-       run: |
-         API_TOKEN=$(jq -r '.inputs.api_token' $GITHUB_EVENT_PATH)
-         echo ::add-mask::$API_TOKEN
-         echo API_TOKEN=$API_TOKEN >> $GITHUB_ENV
-
+    
      - name: Upload testdata
        run: |
         python -m pip install requests
         curl -o transform-and-upload.py https://raw.githubusercontent.com/catenax-ng/tx-item-relationship-service/main/local/testing/testdata/transform-and-upload.py
         if [ "${{ github.event.inputs.environment }}" == "Dev/Test" ]; then
-          python transform-and-upload.py -f ./tx-backend/testdata/CX_Testdata_MessagingTest_v${{ github.event.inputs.testdata_version }}.json -s https://traceability-test.dev.demo.catena-x.net/api/submodel -edc https://trace-x-test-edc.dev.demo.catena-x.net -a https://trace-x-registry-test.dev.demo.catena-x.net/semantics/registry/api/v3.0 -d https://trace-x-test-edc-dataplane.dev.demo.catena-x.net -p id-3.0-trace -k ${{ env.API_TOKEN }}
+          python transform-and-upload.py -f ./tx-backend/testdata/CX_Testdata_MessagingTest_v${{ github.event.inputs.testdata_version }}.json -s https://traceability-test.dev.demo.catena-x.net/api/submodel -edc https://trace-x-test-edc.dev.demo.catena-x.net -a https://trace-x-registry-test.dev.demo.catena-x.net/semantics/registry/api/v3.0 -d https://trace-x-test-edc-dataplane.dev.demo.catena-x.net -p id-3.0-trace -k ${{ secrets.TRACE_X_API_KEY_DEV }} --aas3 --allowedBPNs BPNL00000003CML1 BPNL00000003CNKC
           sleep 10
-          python transform-and-upload.py -f ./tx-backend/testdata/CX_Testdata_MessagingTest_v${{ github.event.inputs.testdata_version }}.json -s https://traceability.dev.demo.catena-x.net/api/submodel -edc https://trace-x-edc.dev.demo.catena-x.net -a https://trace-x-registry.dev.demo.catena-x.net/semantics/registry/api/v3.0 -d https://trace-x-edc-dataplane.dev.demo.catena-x.net -p id-3.0-trace -k ${{ env.API_TOKEN }}
+          python transform-and-upload.py -f ./tx-backend/testdata/CX_Testdata_MessagingTest_v${{ github.event.inputs.testdata_version }}.json -s https://traceability.dev.demo.catena-x.net/api/submodel -edc https://trace-x-edc.dev.demo.catena-x.net -a https://trace-x-registry.dev.demo.catena-x.net/semantics/registry/api/v3.0 -d https://trace-x-edc-dataplane.dev.demo.catena-x.net -p id-3.0-trace -k ${{ secrets.TRACE_X_API_KEY_DEV }} --aas3 --allowedBPNs BPNL00000003CML1 BPNL00000003CNKC
           sleep 10
         elif [ "${{ github.event.inputs.environment }}" == "E2E-A/E2E-B" ]; then
-          python transform-and-upload.py -f ./tx-backend/testdata/CX_Testdata_MessagingTest_v${{ github.event.inputs.testdata_version }}.json -s https://traceability-e2e-a.dev.demo.catena-x.net/api/submodel -edc https://trace-x-edc-e2e-a.dev.demo.catena-x.net -a https://trace-x-registry-e2e-a.dev.demo.catena-x.net/semantics/registry/api/v3.0 -d https://trace-x-edc-e2e-a-dataplane.dev.demo.catena-x.net -p id-3.0-trace -k ${{ env.API_TOKEN }}
+          python transform-and-upload.py -f ./tx-backend/testdata/CX_Testdata_MessagingTest_v${{ github.event.inputs.testdata_version }}.json -s https://traceability-e2e-a.dev.demo.catena-x.net/api/submodel -edc https://trace-x-edc-e2e-a.dev.demo.catena-x.net -a https://trace-x-registry-e2e-a.dev.demo.catena-x.net/semantics/registry/api/v3.0 -d https://trace-x-edc-e2e-a-dataplane.dev.demo.catena-x.net -p id-3.0-trace -k ${{ secrets.TRACE_X_API_KEY_DEV }} --aas3 --allowedBPNs BPNL00000003CML1 BPNL00000003CNKC
           sleep 10
-          python transform-and-upload.py -f ./tx-backend/testdata/CX_Testdata_MessagingTest_v${{ github.event.inputs.testdata_version }}.json -s https://traceability-e2e-b.dev.demo.catena-x.net/api/submodel -edc https://trace-x-edc-e2e-b.dev.demo.catena-x.net -a https://trace-x-registry-e2e-b.dev.demo.catena-x.net/semantics/registry/api/v3.0 -d https://trace-x-edc-e2e-b-dataplane.dev.demo.catena-x.net -p id-3.0-trace -k ${{ env.API_TOKEN }}
+          python transform-and-upload.py -f ./tx-backend/testdata/CX_Testdata_MessagingTest_v${{ github.event.inputs.testdata_version }}.json -s https://traceability-e2e-b.dev.demo.catena-x.net/api/submodel -edc https://trace-x-edc-e2e-b.dev.demo.catena-x.net -a https://trace-x-registry-e2e-b.dev.demo.catena-x.net/semantics/registry/api/v3.0 -d https://trace-x-edc-e2e-b-dataplane.dev.demo.catena-x.net -p id-3.0-trace -k ${{ secrets.TRACE_X_API_KEY_DEV }} --aas3 --allowedBPNs BPNL00000003CML1 BPNL00000003CNKC
           sleep 10
         elif [ "${{ github.event.inputs.environment }}" == "int-a/int-b" ]; then
-          python transform-and-upload.py -f ./tx-backend/testdata/CX_Testdata_MessagingTest_v${{ github.event.inputs.testdata_version }}.json -s https://traceability-int-a.int.demo.catena-x.net/api/submodel -edc https://trace-x-edc-int-a.int.demo.catena-x.net -a https://trace-x-registry-int-a.int.demo.catena-x.net/semantics/registry/api/v3.0 -d https://trace-x-edc-int-a-dataplane.int.demo.catena-x.net -p id-3.0-trace -k ${{ env.API_TOKEN }}
+          python transform-and-upload.py -f ./tx-backend/testdata/CX_Testdata_MessagingTest_v${{ github.event.inputs.testdata_version }}.json -s https://traceability-int-a.int.demo.catena-x.net/api/submodel -edc https://trace-x-edc-int-a.int.demo.catena-x.net -a https://trace-x-registry-int-a.int.demo.catena-x.net/semantics/registry/api/v3.0 -d https://trace-x-edc-int-a-dataplane.int.demo.catena-x.net -p id-3.0-trace -k ${{ secrets.TRACE_X_API_KEY_INT_A }} --aas3 --allowedBPNs BPNL00000003CML1 BPNL00000003CNKC BPNL00000003AZQP BPNL00000003CSGV
           sleep 10
-          python transform-and-upload.py -f ./tx-backend/testdata/CX_Testdata_MessagingTest_v${{ github.event.inputs.testdata_version }}.json -s https://traceability-int-b.int.demo.catena-x.net/api/submodel -edc https://trace-x-edc-int-b.int.demo.catena-x.net -a https://trace-x-registry-int-b.int.demo.catena-x.net/semantics/registry/api/v3.0 -d https://trace-x-edc-int-b-dataplane.int.demo.catena-x.net -p id-3.0-trace -k ${{ env.API_TOKEN }}
+          python transform-and-upload.py -f ./tx-backend/testdata/CX_Testdata_MessagingTest_v${{ github.event.inputs.testdata_version }}.json -s https://traceability-int-b.int.demo.catena-x.net/api/submodel -edc https://trace-x-edc-int-b.int.demo.catena-x.net -a https://trace-x-registry-int-b.int.demo.catena-x.net/semantics/registry/api/v3.0 -d https://trace-x-edc-int-b-dataplane.int.demo.catena-x.net -p id-3.0-trace -k ${{ secrets.TRACE_X_API_KEY_INT_B }} --aas3 --allowedBPNs BPNL00000003CML1 BPNL00000003CNKC BPNL00000003AZQP BPNL00000003CSGV
           sleep 10
         fi
   registry_reload:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Validation check if table-settings correct and reset on invalid state
 - Added Api-Input in Argo Workflow to fix bugs
 - Added implementation for cucumber tests for quality investigations
+- Separation of auto complete mechanism (selected / searched elements)
+-
 ### Changed
 - Filter configuration for tables to be resuable and easy to adapt
 - Realigned some mappings e.g. (manufacturer / manufacturerName) to be more clear

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres
 to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+
 ## [UNRELEASED - DD.MM.YYYY]
 ### Added
 - new filtering capabilities ( receivedQualityAlertIdsInStatusActive, sentQualityAlertIdsInStatusActive, receivedQualityInvestigationIdsInStatusActive, sentQualityInvestigationIdsInStatusActive )
@@ -11,7 +13,8 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Added Api-Input in Argo Workflow to fix bugs
 - Added implementation for cucumber tests for quality investigations
 - Separation of auto complete mechanism (selected / searched elements)
--
+- Added new step definition for cucumber tests "I use assets with ids {string}" allowing to specify assets used for notification creation
+
 ### Changed
 - Filter configuration for tables to be resuable and easy to adapt
 - Realigned some mappings e.g. (manufacturer / manufacturerName) to be more clear
@@ -21,10 +24,12 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Upgraded maven-install-plugin from 3.0.1 to 3.1.1
 - Upgraded json-unit-assertj from 2.38.0 to 3.2.2
 - Upgraded asciidoctorj-diagram from 2.2.9 to 2.2.13
+- Cucumber test steps for creating notifications no longer support default assetId when no asset is provided with previous step
 - Upgraded the Upload_Testdata job in Argo Workflow to fix bugs
 
 ### Removed
 - removed asset filters ( qualityInvestigationIdsInStatusActive, qualityInvestigationIdsInStatusActive )
+- Removed Cucumber tests steps for creating alerts with two parts as new step definition is enough for the same feature
 
 ## [9.0.0-rc4 - xx.xx.2023]
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Upgraded maven-install-plugin from 3.0.1 to 3.1.1
 - Upgraded json-unit-assertj from 2.38.0 to 3.2.2
 - Upgraded asciidoctorj-diagram from 2.2.9 to 2.2.13
+- Upgraded the Upload_Testdata job in Argo Workflow to fix bugs
 
 ### Removed
 - removed asset filters ( qualityInvestigationIdsInStatusActive, qualityInvestigationIdsInStatusActive )

--- a/DEPENDENCIES_BACKEND
+++ b/DEPENDENCIES_BACKEND
@@ -28,7 +28,7 @@ maven/mavencentral/com.google.code.findbugs/jsr305/3.0.2, Apache-2.0, approved, 
 maven/mavencentral/com.jayway.jsonpath/json-path/2.8.0, Apache-2.0, approved, clearlydefined
 maven/mavencentral/com.nimbusds/content-type/2.2, Apache-2.0, approved, clearlydefined
 maven/mavencentral/com.nimbusds/lang-tag/1.7, Apache-2.0, approved, clearlydefined
-maven/mavencentral/com.nimbusds/nimbus-jose-jwt/9.31, Apache-2.0, approved, clearlydefined
+maven/mavencentral/com.nimbusds/nimbus-jose-jwt/9.37.1, Apache-2.0, approved, #11701
 maven/mavencentral/com.nimbusds/oauth2-oidc-sdk/9.43.3, Apache-2.0, approved, clearlydefined
 maven/mavencentral/com.squareup.okhttp3/okhttp-dnsoverhttps/4.10.0, Apache-2.0, approved, clearlydefined
 maven/mavencentral/com.squareup.okhttp3/okhttp-dnsoverhttps/4.11.0, Apache-2.0, approved, clearlydefined
@@ -123,9 +123,9 @@ maven/mavencentral/net.bytebuddy/byte-buddy-agent/1.14.6, Apache-2.0, approved, 
 maven/mavencentral/net.bytebuddy/byte-buddy/1.12.21, Apache-2.0 AND BSD-3-Clause, approved, #1811
 maven/mavencentral/net.bytebuddy/byte-buddy/1.14.6, Apache-2.0 AND BSD-3-Clause, approved, #7163
 maven/mavencentral/net.java.dev.jna/jna/5.12.1, Apache-2.0 OR LGPL-2.1-or-later, approved, #3217
-maven/mavencentral/net.javacrumbs.json-unit/json-unit-assertj/2.38.0, Apache-2.0, approved, clearlydefined
-maven/mavencentral/net.javacrumbs.json-unit/json-unit-core/2.38.0, Apache-2.0, approved, clearlydefined
-maven/mavencentral/net.javacrumbs.json-unit/json-unit-json-path/2.38.0, Apache-2.0, approved, #11049
+maven/mavencentral/net.javacrumbs.json-unit/json-unit-assertj/3.2.2, Apache-2.0, approved, clearlydefined
+maven/mavencentral/net.javacrumbs.json-unit/json-unit-core/3.2.2, Apache-2.0, approved, clearlydefined
+maven/mavencentral/net.javacrumbs.json-unit/json-unit-json-path/3.2.2, Apache-2.0, approved, clearlydefined
 maven/mavencentral/net.javacrumbs.shedlock/shedlock-core/5.9.1, Apache-2.0, approved, #11246
 maven/mavencentral/net.javacrumbs.shedlock/shedlock-provider-jdbc-template/5.9.1, Apache-2.0, approved, #11245
 maven/mavencentral/net.javacrumbs.shedlock/shedlock-spring/5.9.1, Apache-2.0, approved, #11247
@@ -160,7 +160,7 @@ maven/mavencentral/org.apache.tomcat.embed/tomcat-embed-websocket/10.1.15, Apach
 maven/mavencentral/org.apache.tomcat/tomcat-annotations-api/10.1.12, Apache-2.0, approved, #8196
 maven/mavencentral/org.apache.tomcat/tomcat-annotations-api/10.1.15, Apache-2.0, approved, #8196
 maven/mavencentral/org.apiguardian/apiguardian-api/1.1.2, Apache-2.0, approved, clearlydefined
-maven/mavencentral/org.aspectj/aspectjweaver/1.9.20, EPL-1.0, approved, tools.aspectj
+maven/mavencentral/org.aspectj/aspectjweaver/1.9.20, Apache-2.0 AND BSD-3-Clause AND EPL-1.0 AND BSD-3-Clause AND Apache-1.1, approved, #7695
 maven/mavencentral/org.assertj/assertj-core/3.24.2, Apache-2.0, approved, #6161
 maven/mavencentral/org.attoparser/attoparser/2.0.7.RELEASE, Apache-2.0, approved, CQ18900
 maven/mavencentral/org.awaitility/awaitility-proxy/3.0.0, Apache-2.0, approved, #11044

--- a/DEPENDENCIES_FRONTEND
+++ b/DEPENDENCIES_FRONTEND
@@ -709,7 +709,7 @@ npm/npmjs/-/node-hook/1.0.0, MIT, approved, clearlydefined
 npm/npmjs/-/node-releases/2.0.10, MIT, approved, #1954
 npm/npmjs/-/nopt/6.0.0, ISC, approved, clearlydefined
 npm/npmjs/-/normalize-package-data/2.5.0, BSD-2-Clause AND Apache-2.0 AND MIT, approved, #2499
-npm/npmjs/-/normalize-package-data/3.0.3, BSD-2-Clause, approved, clearlydefined
+npm/npmjs/-/normalize-package-data/3.0.3, BSD-2-Clause, approved, #11614
 npm/npmjs/-/normalize-package-data/5.0.0, BSD-3-Clause, approved, #5757
 npm/npmjs/-/normalize-path/3.0.0, MIT, approved, clearlydefined
 npm/npmjs/-/normalize-range/0.1.2, MIT, approved, clearlydefined
@@ -742,7 +742,7 @@ npm/npmjs/-/onetime/5.1.2, MIT, approved, clearlydefined
 npm/npmjs/-/onetime/6.0.0, MIT, approved, clearlydefined
 npm/npmjs/-/open/8.4.1, MIT, approved, #7102
 npm/npmjs/-/open/8.4.2, MIT, approved, #7102
-npm/npmjs/-/opener/1.5.2, MIT OR WTFPL OR (MIT AND WTFPL), approved, clearlydefined
+npm/npmjs/-/opener/1.5.2, MIT AND WTFPL AND WTFPL, approved, #11619
 npm/npmjs/-/optionator/0.9.1, MIT, approved, #9208
 npm/npmjs/-/ora/5.4.1, MIT, approved, clearlydefined
 npm/npmjs/-/os-tmpdir/1.0.2, MIT, approved, clearlydefined

--- a/frontend/src/app/modules/shared/components/multi-select-autocomplete/multi-select-autocomplete.component.html
+++ b/frontend/src/app/modules/shared/components/multi-select-autocomplete/multi-select-autocomplete.component.html
@@ -41,15 +41,21 @@ SPDX-License-Identifier: Apache-2.0
 
       <!-- hidden element just so that the mat-select dropdown opens -->
       <mat-option [style.display]="'none'"></mat-option>
+
       <div class="pl-1" *ngIf="suggestionError">{{'multiSelect.suggestionError' | i18n}}</div>
+        <ng-container>
+            <mat-option  *ngFor="let option of optionsSelected" [disabled]="option.disabled" [value]="option.value">{{option.display}}
+            </mat-option>
+        </ng-container>
+
+      <mat-divider></mat-divider>
       <ng-container *ngIf="options?.length">
-        <mat-option  *ngFor="let option of options" [disabled]="option.disabled" [value]="option.value"
-                     [style.display]="hideOption(option) ? 'none': 'flex'">{{option.display}}
+        <mat-option  *ngFor="let option of options" [disabled]="option.disabled" [value]="option.value">{{option.display}}
         </mat-option>
       </ng-container>
 
-      <mat-option *ngIf="singleSearch" (click)="changeSearchTextOption()" [value]=this.searchElement
-                  [style.display]="this.shouldHideTextSearchOptionField() ? 'none': 'flex'">{{this.searchElement}}
+      <mat-option *ngIf="singleSearch" (click)="changeSearchTextOptionSingleSearch()" [value]=this.searchElement
+                  [style.display]="this.shouldHideTextSearchOptionFieldSingleSearch() ? 'none': 'flex'">{{this.searchElement}}
       </mat-option>
       <mat-select-trigger  *ngIf="selectedValue?.length > 1">
        <div>

--- a/frontend/src/app/modules/shared/components/multi-select-autocomplete/multi-select-autocomplete.component.spec.ts
+++ b/frontend/src/app/modules/shared/components/multi-select-autocomplete/multi-select-autocomplete.component.spec.ts
@@ -33,21 +33,6 @@ describe('MultiSelectAutocompleteComponent', () => {
     });
 
 
-    it('should emit selectionChange event when options are selected', async () => {
-        const {fixture} = await renderMultiSelectAutoCompleteComponent();
-        const {componentInstance} = fixture;
-
-        componentInstance.searchElement = 'B'
-        const selectedOptions = [SemanticDataModel.BATCH];
-        componentInstance.selectedValue = selectedOptions;
-        fixture.detectChanges();
-
-        const spy = spyOn(componentInstance.selectionChange, 'emit');
-        componentInstance.onSelectionChange({value: selectedOptions});
-
-        expect(spy).toHaveBeenCalledWith(selectedOptions);
-    });
-
     it('should clear values when clickClear is called', async () => {
         const {fixture} = await renderMultiSelectAutoCompleteComponent();
         const {componentInstance} = fixture;
@@ -58,6 +43,8 @@ describe('MultiSelectAutocompleteComponent', () => {
         componentInstance.startDate = new Date('2022-02-04');
         componentInstance.endDate = new Date('2022-02-04');
         componentInstance.filteredOptions = ['test']
+        componentInstance.searchedOptions = [];
+        componentInstance.allOptions = [];
 
         componentInstance.clickClear();
 
@@ -187,7 +174,6 @@ describe('MultiSelectAutocompleteComponent', () => {
         componentInstance.startDateSelected(event);
 
 
-
         // Expectations
         expect(componentInstance.searchElement).toEqual('2023-10-12');
     });
@@ -299,29 +285,6 @@ describe('MultiSelectAutocompleteComponent', () => {
         expect(componentInstance.delayTimeoutId).toBeNull();
     });
 
-    it('should change searchtext option', async () => {
-        const {fixture} = await renderMultiSelectAutoCompleteComponent();
-        const {componentInstance} = fixture;
-
-        const searchElementChangeSpy = spyOn(componentInstance.selectionChange, 'emit');
-
-        componentInstance.selectedValue = ['test'];
-        componentInstance.changeSearchTextOption();
-        expect(componentInstance.formControl.value).toEqual(['test']);
-        expect(searchElementChangeSpy).toHaveBeenCalledWith(['test']);
-    })
-
-    it('should return when calling displayValue() without searchElement', async () => {
-        const {fixture} = await renderMultiSelectAutoCompleteComponent();
-        const {componentInstance} = fixture;
-
-        componentInstance.searchElement = '';
-        componentInstance.displayValue();
-
-        const dValue = componentInstance.displayValue();
-        expect(dValue).toEqual(undefined);
-    })
-
     it('should return when calling filterItem() without searchElement', async () => {
         const {fixture} = await renderMultiSelectAutoCompleteComponent();
         const {componentInstance} = fixture;
@@ -344,20 +307,7 @@ describe('MultiSelectAutocompleteComponent', () => {
         expect(option).toEqual([]);
     })
 
-    it('should return when calling filterItem() without value', async () => {
-        const {fixture} = await renderMultiSelectAutoCompleteComponent();
-        const {componentInstance} = fixture;
 
-        componentInstance.searchElement = ''; // Set searchElement to an empty string
-        spyOn(componentInstance, 'getFilteredOptionsValues'); // Mock any necessary methods
-
-        // Act
-        componentInstance.onSelectionChange({ value: 'someValue' });
-
-        // Assert
-        // Add assertions as needed, for example:
-        expect(componentInstance.selectedValue).toEqual(null);
-    })
 
     it('should stop event propagation for Enter key and Ctrl+A combination', async() => {
         // Arrange

--- a/frontend/src/app/modules/shared/components/multi-select-autocomplete/multi-select-autocomplete.component.ts
+++ b/frontend/src/app/modules/shared/components/multi-select-autocomplete/multi-select-autocomplete.component.ts
@@ -17,310 +17,332 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
-import { DatePipe, registerLocaleData } from '@angular/common';
+import {DatePipe, registerLocaleData} from '@angular/common';
 import localeDe from '@angular/common/locales/de';
 import localeDeExtra from '@angular/common/locales/extra/de';
-import { Component, EventEmitter, Inject, Input, LOCALE_ID, OnChanges, Output, ViewChild } from '@angular/core';
-import { FormControl } from '@angular/forms';
-import { DateAdapter, MAT_DATE_LOCALE } from '@angular/material/core';
-import { MatDatepickerInputEvent } from '@angular/material/datepicker';
-import { Owner } from '@page/parts/model/owner.enum';
-import { PartTableType } from '@shared/components/table/table.model';
-import { FormatPartSemanticDataModelToCamelCasePipe } from '@shared/pipes/format-part-semantic-data-model-to-camelcase.pipe';
-import { PartsService } from '@shared/service/parts.service';
-import { firstValueFrom } from 'rxjs';
+import {Component, EventEmitter, Inject, Input, LOCALE_ID, OnChanges, ViewChild} from '@angular/core';
+import {FormControl} from '@angular/forms';
+import {DateAdapter, MAT_DATE_LOCALE} from '@angular/material/core';
+import {MatDatepickerInputEvent} from '@angular/material/datepicker';
+import {Owner} from '@page/parts/model/owner.enum';
+import {PartTableType} from '@shared/components/table/table.model';
+import {
+    FormatPartSemanticDataModelToCamelCasePipe
+} from '@shared/pipes/format-part-semantic-data-model-to-camelcase.pipe';
+import {PartsService} from '@shared/service/parts.service';
+import {firstValueFrom} from 'rxjs';
+import {MatSelectChange} from "@angular/material/select";
 
 @Component({
-  selector: 'app-multiselect',
-  templateUrl: 'multi-select-autocomplete.component.html',
-  styleUrls: [ 'multi-select-autocomplete.component.scss' ],
+    selector: 'app-multiselect',
+    templateUrl: 'multi-select-autocomplete.component.html',
+    styleUrls: ['multi-select-autocomplete.component.scss'],
 })
 
 export class MultiSelectAutocompleteComponent implements OnChanges {
 
-  @Input()
-  placeholder: string;
-  @Input()
-  options: any;
-  @Input()
-  disabled = false;
-  @Input()
-  display = 'display';
-  @Input()
-  value = 'value';
-  @Input()
-  formControl = new FormControl();
-  @Input()
-  placeholderMultiple;
-  @Input()
-  singleSearch = false;
+    @Input()
+    placeholder: string;
+    @Input()
+    options: any;
+    allOptions: any;
+    searchedOptions: any;
+    optionsSelected: any;
+    @Input()
+    disabled = false;
+    @Input()
+    display = 'display';
+    @Input()
+    value = 'value';
+    @Input()
+    formControl = new FormControl();
+    @Input()
+    placeholderMultiple;
+    @Input()
+    singleSearch = false;
 
-  @Input()
-  selectedOptions;
+    @Input()
+    selectedOptions;
 
-  @Input()
-  isDate = false;
+    @Input()
+    isDate = false;
 
-  // New Options
-  @Input()
-  labelCount = 1;
-  @Input()
-  appearance = 'standard';
+    // New Options
+    @Input()
+    labelCount = 1;
+    @Input()
+    appearance = 'standard';
 
-  @Input()
-  filterColumn = null;
+    @Input()
+    filterColumn = null;
 
-  @Input()
-  partTableType = PartTableType.AS_BUILT_OWN;
+    @Input()
+    partTableType = PartTableType.AS_BUILT_OWN;
 
-  @Input()
-  isAsBuilt: boolean;
+    @Input()
+    isAsBuilt: boolean;
 
-  public readonly minDate = new Date();
+    public readonly minDate = new Date();
 
-  @ViewChild('searchInput', { static: true }) searchInput: any;
+    @ViewChild('searchInput', {static: true}) searchInput: any;
 
-  searchElement: string = '';
+    searchElement: string = '';
 
-  searchElementChange: EventEmitter<any> = new EventEmitter();
+    searchElementChange: EventEmitter<any> = new EventEmitter();
 
-  @Output()
-  selectionChange: EventEmitter<any> = new EventEmitter();
+    @ViewChild('selectElem', {static: true}) selectElem: any;
 
-  @ViewChild('selectElem', { static: true }) selectElem: any;
+    filteredOptions: Array<any> = [];
+    selectedValue: Array<any> = [];
+    selectAllChecked = false;
 
-  filteredOptions: Array<any> = [];
-  selectedValue: Array<any> = [];
-  selectAllChecked = false;
+    startDate: Date;
+    endDate: Date;
 
-  startDate: Date;
-  endDate: Date;
+    delayTimeoutId: any;
 
-  delayTimeoutId: any;
+    suggestionError: boolean = false;
 
-  suggestionError: boolean = false;
+    isLoadingSuggestions: boolean;
 
-  isLoadingSuggestions: boolean;
+    constructor(public datePipe: DatePipe, public _adapter: DateAdapter<any>,
+                @Inject(MAT_DATE_LOCALE) public _locale: string, @Inject(LOCALE_ID) private locale: string, public partsService: PartsService, private readonly formatPartSemanticDataModelToCamelCasePipe: FormatPartSemanticDataModelToCamelCasePipe) {
+        registerLocaleData(localeDe, 'de', localeDeExtra);
+        this._adapter.setLocale(locale);
+    }
 
-  constructor(public datePipe: DatePipe, public _adapter: DateAdapter<any>,
-              @Inject(MAT_DATE_LOCALE) public _locale: string, @Inject(LOCALE_ID) private locale: string, public partsService: PartsService, private readonly formatPartSemanticDataModelToCamelCasePipe: FormatPartSemanticDataModelToCamelCasePipe) {
-    registerLocaleData(localeDe, 'de', localeDeExtra);
-    this._adapter.setLocale(locale);
-  }
-
-  ngOnInit(): void {
-    this.searchElementChange.subscribe((value) => {
-      if (this.delayTimeoutId) {
-        clearTimeout(this.delayTimeoutId);
-        this.delayTimeoutId = null;
-        this.filterItem(value);
-      }
-    });
-  }
-
-  ngOnChanges(): void {
-    this.selectedValue = this.formControl.value;
-    this.formControl.patchValue(this.selectedValue);
-  }
-
-  toggleSelectAll = function(selectCheckbox: any): void {
-
-    if (selectCheckbox.checked) {
-      // if there are no suggestion but the selectAll checkbox was checked
-      if (!this.filteredOptions.length) {
-        this.formControl.patchValue(this.searchElement);
-        this.selectedValue = this.searchElement as unknown as [];
-      } else {
-        this.filteredOptions.forEach(option => {
-          if (!this.selectedValue.includes(option[this.value])) {
-            this.selectedValue = this.selectedValue.concat([ option[this.value] ]);
-          }
+    ngOnInit(): void {
+        this.searchElementChange.subscribe((value) => {
+            if (this.delayTimeoutId) {
+                clearTimeout(this.delayTimeoutId);
+                this.delayTimeoutId = null;
+                this.filterItem(value);
+            }
         });
-      }
 
-    } else {
-      this.selectedValue = [];
-    }
-    this.formControl.patchValue(this.selectedValue);
-    this.selectionChange.emit(this.selectedValue);
-  };
-
-  changeSearchTextOption() {
-    this.formControl.patchValue(this.selectedValue);
-    this.selectionChange.emit(this.selectedValue);
-  }
-
-  shouldHideTextSearchOptionField() {
-    return this.searchElement === null || this.searchElement === undefined || this.searchElement === '';
-  }
-
-  displayValue() {
-    if(!this.searchElement.length) {
-      return;
-    }
-    let suffix = '';
-    let displayValue;
-    // add +X others label if multiple
-    if (this.selectedValue?.length > 1) {
-      suffix = (' + ' + (this.selectedValue?.length - 1)) + ' ' + this.placeholderMultiple;
     }
 
-    // apply CamelCase to semanticDataModel labels
-    if (this.filterColumn === 'semanticDataModel') {
-      displayValue = this.formatPartSemanticDataModelToCamelCasePipe.transformModel(this.selectedValue[0]) + suffix;
-    } else {
-      displayValue = this.selectedValue[0] + suffix;
+    ngOnChanges(): void {
+        this.selectedValue = this.formControl.value;
+        this.formControl.patchValue(this.selectedValue);
     }
 
-    // if no value selected, return empty string
-    if(!this.selectedValue.length) {
-      displayValue = ''
-    }
+    toggleSelectAll = function (selectCheckbox: any): void {
 
-    return displayValue;
-  }
+        if (selectCheckbox.checked) {
+            // if there are no suggestion but the selectAll checkbox was checked
+            if (!this.filteredOptions.length) {
+                this.formControl.patchValue(this.searchElement);
+                this.selectedValue = this.searchElement as unknown as [];
+            } else {
+                this.filteredOptions.forEach(option => {
+                    if (!this.selectedValue.includes(option[this.value])) {
+                        this.selectedValue = this.selectedValue.concat([option[this.value]]);
+                    }
+                });
+            }
 
-  filterItem(value: any): void {
-    if(!this.searchElement.length) {
-      return;
-    }
-
-    if (!value) {
-      this.filteredOptions = [];
-      return;
-    }
-
-    if (this.singleSearch) {
-      return;
-    }
-
-    // emit an event that the searchElement changed
-    // if there is a timeout currently, abort the changes.
-    if (this.delayTimeoutId) {
-      this.searchElementChange.emit(value);
-      return;
-    }
-
-    // if there is no timeout currently, start the delay
-    const timeoutCallback = (): void => {
-      this.isLoadingSuggestions = true;
-      const tableOwner = this.getOwnerOfTable(this.partTableType);
-
-      try {
-        firstValueFrom(this.partsService.getDistinctFilterValues(
-            this.isAsBuilt,
-            tableOwner,
-            this.filterColumn,
-            this.searchElement
-        )).then((res) => {
-          if (this.filterColumn === 'semanticDataModel') {
-            this.options = res.map(option => ({
-              display: this.formatPartSemanticDataModelToCamelCasePipe.transformModel(option),
-              value: option,
-            }));
-          } else {
-            this.options = res.map(option => ({ display: option, value: option }));
-          }
-
-          this.filteredOptions = this.options;
-          this.suggestionError = !this.filteredOptions.length;
-        }).catch((error) => {
-          console.error('Error fetching data: ', error);
-          this.suggestionError = !this.filteredOptions.length;
-        }).finally(() => {
-          this.delayTimeoutId = null;
-          this.isLoadingSuggestions = false;
-        });
-      } catch (error) {
-        console.error('Error in timeoutCallback: ', error);
-      }
+        } else {
+            this.selectedValue = [];
+        }
+        this.formControl.patchValue(this.selectedValue);
     };
 
-    // Start the delay with the callback
-    this.delayTimeoutId = setTimeout(timeoutCallback, 500);
-  }
-
-// This is used by parent component
-  isUnsupportedAutoCompleteField(fieldName: string) {
-    return fieldName === 'activeAlerts' || fieldName === 'activeInvestigations';
-  }
-
-  hideOption(option: any): boolean {
-    if(!this.searchElement.length) {
-      return true;
+    changeSearchTextOptionSingleSearch() {
+        this.formControl.patchValue(this.selectedValue);
     }
-    return !(this.filteredOptions.indexOf(option) > -1);
-  }
 
-  // Returns plain strings array of filtered values
-  getFilteredOptionsValues(): string[] {
-    const filteredValues = [];
-    this.filteredOptions.forEach(option => {
-      if(option.length) {
-          filteredValues.push(option.value);
-      }
-    });
-    return filteredValues;
-  }
-
-  startDateSelected(event: MatDatepickerInputEvent<Date>) {
-    this.startDate = event.value;
-    this.searchElement = this.datePipe.transform(this.startDate, 'yyyy-MM-dd');
-  }
-
-  endDateSelected(event: MatDatepickerInputEvent<Date>) {
-    this.endDate = event.value;
-    if (!this.endDate) {
-      return;
+    shouldHideTextSearchOptionFieldSingleSearch() {
+        return this.searchElement === null || this.searchElement === undefined || this.searchElement === '';
     }
-    this.searchElement += ',' + this.datePipe.transform(this.endDate, 'yyyy-MM-dd');
-  }
 
-  clickClear(): void {
-    this.formControl.patchValue('');
-    this.formControl.reset();
-    this.searchElement = '';
-    this.selectedValue = [];
-    this.startDate = null;
-    this.endDate = null;
-    this.filteredOptions = [];
-  }
+    displayValue() {
+        let suffix = '';
+        let displayValue;
+        // add +X others label if multiple
+        if (this.selectedValue?.length > 1) {
+            suffix = (' + ' + (this.selectedValue?.length - 1)) + ' ' + this.placeholderMultiple;
+        }
 
-  dateFilter(){
-    this.formControl.patchValue(this.searchElement);
-  }
+        // apply CamelCase to semanticDataModel labels
+        if (this.filterColumn === 'semanticDataModel') {
+            displayValue = this.formatPartSemanticDataModelToCamelCasePipe.transformModel(this.selectedValue[0]) + suffix;
+        } else {
+            displayValue = this.selectedValue[0] + suffix;
+        }
 
+        // if no value selected, return empty string
+        if (!this.selectedValue.length) {
+            displayValue = ''
+        }
 
-  onSelectionChange(val: any) {
-    if(!this.searchElement.length) {
-      return;
+        return displayValue;
     }
-    const filteredValues = this.getFilteredOptionsValues();
 
-    const selectedCount = this.selectedValue.filter(item => filteredValues.includes(item)).length;
-    this.selectAllChecked = selectedCount === this.filteredOptions.length;
+    filterItem(value: any): void {
 
-    this.selectedValue = val.value;
-    this.formControl.patchValue(val.value);
-    this.selectionChange.emit(this.selectedValue);
-    this.searchElement = this.displayValue();
-  }
+        if (!this.searchElement.length) {
+            return;
+        }
 
-  getOwnerOfTable(partTableType: PartTableType): Owner {
-    if (partTableType === PartTableType.AS_BUILT_OWN || partTableType === PartTableType.AS_PLANNED_OWN) {
-      return Owner.OWN;
-    } else if (partTableType === PartTableType.AS_BUILT_CUSTOMER || partTableType === PartTableType.AS_PLANNED_CUSTOMER) {
-      return Owner.CUSTOMER;
-    } else if (partTableType === PartTableType.AS_BUILT_SUPPLIER || partTableType === PartTableType.AS_PLANNED_SUPPLIER) {
-      return Owner.SUPPLIER;
-    } else {
-      return Owner.UNKNOWN;
+        if (!value) {
+            this.filteredOptions = [];
+            return;
+        }
+
+        if (this.singleSearch) {
+            return;
+        }
+
+        // emit an event that the searchElement changed
+        // if there is a timeout currently, abort the changes.
+        if (this.delayTimeoutId) {
+            this.searchElementChange.emit(value);
+            return;
+        }
+
+        // if there is no timeout currently, start the delay
+        const timeoutCallback = (): void => {
+            this.isLoadingSuggestions = true;
+            const tableOwner = this.getOwnerOfTable(this.partTableType);
+
+            try {
+                firstValueFrom(this.partsService.getDistinctFilterValues(
+                    this.isAsBuilt,
+                    tableOwner,
+                    this.filterColumn,
+                    this.searchElement
+                )).then((res) => {
+                    if (this.filterColumn === 'semanticDataModel') {
+                        this.searchedOptions = res
+                            .filter(option => !this.selectedValue.includes(option))
+                            .map(option => ({display: this.formatPartSemanticDataModelToCamelCasePipe.transformModel(option), value: option}));
+                        this.options = this.searchedOptions;
+                        this.allOptions = res.map(option => ({display: this.formatPartSemanticDataModelToCamelCasePipe.transformModel(option), value: option}));
+
+                    } else {
+                        // add filter for not selected
+                        this.searchedOptions = res
+                            .filter(option => !this.selectedValue.includes(option))
+                            .map(option => ({display: option, value: option}));
+                        this.options = this.searchedOptions;
+                        this.allOptions = res.map(option => ({display: option, value: option}));
+                    }
+
+                    this.filteredOptions = this.searchedOptions;
+                    this.suggestionError = !this.filteredOptions?.length;
+                }).catch((error) => {
+                    console.error('Error fetching data: ', error);
+                    this.suggestionError = !this.filteredOptions.length;
+                }).finally(() => {
+                    this.delayTimeoutId = null;
+                    this.isLoadingSuggestions = false;
+                });
+            } catch (error) {
+                console.error('Error in timeoutCallback: ', error);
+            }
+        };
+
+        // Start the delay with the callback
+        this.delayTimeoutId = setTimeout(timeoutCallback, 500);
     }
-  }
+
+    // DO NOT REMOVE: Used by parent component
+    isUnsupportedAutoCompleteField(fieldName: string) {
+        return fieldName === 'activeAlerts' || fieldName === 'activeInvestigations';
+    }
+
+
+    // Returns plain strings array of filtered values
+    getFilteredOptionsValues(): string[] {
+        const filteredValues = [];
+        this.filteredOptions.forEach(option => {
+            if (option.length) {
+                filteredValues.push(option.value);
+            }
+        });
+        return filteredValues;
+    }
+
+    startDateSelected(event: MatDatepickerInputEvent<Date>) {
+        this.startDate = event.value;
+        this.searchElement = this.datePipe.transform(this.startDate, 'yyyy-MM-dd');
+    }
+
+    endDateSelected(event: MatDatepickerInputEvent<Date>) {
+        this.endDate = event.value;
+        if (!this.endDate) {
+            return;
+        }
+        this.searchElement += ',' + this.datePipe.transform(this.endDate, 'yyyy-MM-dd');
+    }
+
+    clickClear(): void {
+        this.formControl.patchValue('');
+        this.formControl.reset();
+        this.searchElement = '';
+
+        this.startDate = null;
+        this.endDate = null;
+        this.filteredOptions = [];
+        this.updateOptionsAndSelections();
+        this.selectedValue = [];
+    }
+
+    private updateOptionsAndSelections() {
+        if (this.singleSearch) {
+            return;
+        }
+        // TODO the issue is that the selectedValue is already empty but still needs to be readded to the options if unselected
+        this.options = this.allOptions.filter(option => !this.selectedValue.includes(option.value));
+        if (!this.selectedValue) {
+            this.options = this.allOptions;
+        }
+
+
+        console.log("search options after update", this.searchedOptions);
+        console.log("options after update", this.options);
+
+        console.log(this.allOptions, "all options in change");
+
+        const filter = this.searchedOptions.filter(val => this.selectedValue.includes(val));
+        for (const selected of this.selectedValue) {
+            filter.push({display: selected, value: selected})
+        }
+        this.optionsSelected = filter;
+    }
+
+    dateFilter() {
+        this.formControl.patchValue(this.searchElement);
+    }
+
+
+    onSelectionChange(matSelectChange: MatSelectChange) {
+
+        const filteredValues = this.getFilteredOptionsValues();
+        const selectedCount = this.selectedValue.filter(item => filteredValues.includes(item)).length;
+        this.selectAllChecked = selectedCount === this.filteredOptions.length;
+
+        this.selectedValue = matSelectChange.value;
+        this.formControl.patchValue(matSelectChange.value);
+        this.updateOptionsAndSelections();
+    }
+
+    getOwnerOfTable(partTableType: PartTableType): Owner {
+        if (partTableType === PartTableType.AS_BUILT_OWN || partTableType === PartTableType.AS_PLANNED_OWN) {
+            return Owner.OWN;
+        } else if (partTableType === PartTableType.AS_BUILT_CUSTOMER || partTableType === PartTableType.AS_PLANNED_CUSTOMER) {
+            return Owner.CUSTOMER;
+        } else if (partTableType === PartTableType.AS_BUILT_SUPPLIER || partTableType === PartTableType.AS_PLANNED_SUPPLIER) {
+            return Owner.SUPPLIER;
+        } else {
+            return Owner.UNKNOWN;
+        }
+    }
 
     filterKeyCommands(event: any) {
-    if (event.key === 'Enter' || (event.ctrlKey && event.key === 'a' || event.key === ' ')) {
-          event.stopPropagation();
+        if (event.key === 'Enter' || (event.ctrlKey && event.key === 'a' || event.key === ' ')) {
+            event.stopPropagation();
         }
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -92,6 +92,7 @@ SPDX-License-Identifier: Apache-2.0
         <springdoc.version>2.0.4</springdoc.version>
         <assertj.version>3.24.2</assertj.version>
         <commons-logging.version>1.2</commons-logging.version>
+        <commons-collections.version>4.4</commons-collections.version>
         <lombok.version>1.18.28</lombok.version>
         <json-unit-assertj.version>3.2.2</json-unit-assertj.version>
         <cucumber.version>7.12.1</cucumber.version>

--- a/tx-backend/src/main/java/org/eclipse/tractusx/traceability/qualitynotification/domain/base/exception/SendNotificationException.java
+++ b/tx-backend/src/main/java/org/eclipse/tractusx/traceability/qualitynotification/domain/base/exception/SendNotificationException.java
@@ -23,4 +23,8 @@ public class SendNotificationException extends RuntimeException {
     public SendNotificationException(final String message, final Throwable exception) {
         super(message, exception);
     }
+
+    public SendNotificationException(final String message) {
+        super(message);
+    }
 }

--- a/tx-backend/src/main/java/org/eclipse/tractusx/traceability/qualitynotification/domain/base/service/AbstractQualityNotificationService.java
+++ b/tx-backend/src/main/java/org/eclipse/tractusx/traceability/qualitynotification/domain/base/service/AbstractQualityNotificationService.java
@@ -23,6 +23,7 @@ import org.eclipse.tractusx.traceability.assets.domain.asbuilt.service.AssetAsBu
 import org.eclipse.tractusx.traceability.common.model.PageResult;
 import org.eclipse.tractusx.traceability.common.model.SearchCriteria;
 import org.eclipse.tractusx.traceability.qualitynotification.application.base.service.QualityNotificationService;
+import org.eclipse.tractusx.traceability.qualitynotification.domain.base.exception.SendNotificationException;
 import org.eclipse.tractusx.traceability.qualitynotification.domain.base.model.QualityNotification;
 import org.eclipse.tractusx.traceability.qualitynotification.domain.base.model.QualityNotificationId;
 import org.eclipse.tractusx.traceability.qualitynotification.domain.base.model.QualityNotificationSide;
@@ -63,7 +64,13 @@ public abstract class AbstractQualityNotificationService implements QualityNotif
     @Override
     public void update(Long notificationId, QualityNotificationStatus notificationStatus, String reason) {
         QualityNotification alert = loadOrNotFoundException(new QualityNotificationId(notificationId));
-        QualityNotification updatedAlert = getNotificationPublisherService().updateNotificationPublisher(alert, notificationStatus, reason);
+        QualityNotification updatedAlert;
+        try {
+             updatedAlert = getNotificationPublisherService().updateNotificationPublisher(alert, notificationStatus, reason);
+        }catch (SendNotificationException exception) {
+            log.info("Notification status rollback", exception);
+            return;
+        }
 
         getAssetAsBuiltServiceImpl().setAssetsAlertStatus(updatedAlert);
         getQualityNotificationRepository().updateQualityNotificationEntity(updatedAlert);
@@ -78,7 +85,13 @@ public abstract class AbstractQualityNotificationService implements QualityNotif
     @Override
     public void approve(Long notificationId) {
         QualityNotification notification = loadOrNotFoundException(new QualityNotificationId(notificationId));
-        final QualityNotification approvedInvestigation = getNotificationPublisherService().approveNotification(notification);
+        final QualityNotification approvedInvestigation;
+        try {
+             approvedInvestigation = getNotificationPublisherService().approveNotification(notification);
+        } catch (SendNotificationException exception) {
+            log.info("Notification status rollback", exception);
+            return;
+        }
         getQualityNotificationRepository().updateQualityNotificationEntity(approvedInvestigation);
     }
 

--- a/tx-backend/src/main/java/org/eclipse/tractusx/traceability/qualitynotification/domain/base/service/NotificationPublisherService.java
+++ b/tx-backend/src/main/java/org/eclipse/tractusx/traceability/qualitynotification/domain/base/service/NotificationPublisherService.java
@@ -31,6 +31,7 @@ import org.eclipse.tractusx.traceability.assets.domain.base.model.AssetBase;
 import org.eclipse.tractusx.traceability.bpn.domain.service.BpnRepository;
 import org.eclipse.tractusx.traceability.common.model.BPN;
 import org.eclipse.tractusx.traceability.common.properties.TraceabilityProperties;
+import org.eclipse.tractusx.traceability.qualitynotification.domain.base.exception.SendNotificationException;
 import org.eclipse.tractusx.traceability.qualitynotification.domain.base.model.QualityNotification;
 import org.eclipse.tractusx.traceability.qualitynotification.domain.base.model.QualityNotificationAffectedPart;
 import org.eclipse.tractusx.traceability.qualitynotification.domain.base.model.QualityNotificationMessage;
@@ -38,6 +39,7 @@ import org.eclipse.tractusx.traceability.qualitynotification.domain.base.model.Q
 import org.eclipse.tractusx.traceability.qualitynotification.domain.base.model.QualityNotificationSide;
 import org.eclipse.tractusx.traceability.qualitynotification.domain.base.model.QualityNotificationStatus;
 import org.eclipse.tractusx.traceability.qualitynotification.domain.base.model.exception.QualityNotificationIllegalUpdate;
+import org.eclipse.tractusx.traceability.qualitynotification.domain.repository.QualityNotificationRepository;
 import org.springframework.stereotype.Service;
 
 import java.time.Clock;
@@ -207,16 +209,18 @@ public class NotificationPublisherService {
      */
     public QualityNotification approveNotification(QualityNotification notification) {
         BPN applicationBPN = traceabilityProperties.getBpn();
-
+        notification.send(applicationBPN);
         // For each asset within investigation a notification was created before
         List<CompletableFuture<QualityNotificationMessage>> futures = notification.getNotifications().stream()
-                .map(edcNotificationService::asyncNotificationMessageExecutor).filter(Objects::nonNull).toList();
+                .map(edcNotificationService::asyncNotificationMessageExecutor)
+                .filter(Objects::nonNull)
+                .toList();
         List<QualityNotificationMessage> sentMessages = futures.stream()
                 .map(CompletableFuture::join)
                 .filter(Objects::nonNull)
                 .toList();
-        if (!sentMessages.isEmpty()) {
-            notification.send(applicationBPN);
+        if (sentMessages.isEmpty()) {
+            throw new SendNotificationException("No Message was sent");
         }
         return notification;
     }
@@ -237,26 +241,31 @@ public class NotificationPublisherService {
         log.info("::updateNotificationPublisher::allLatestNotificationForEdcNotificationId {}", allLatestNotificationForEdcNotificationId);
         allLatestNotificationForEdcNotificationId.forEach(qNotification -> {
             QualityNotificationMessage notificationToSend = qNotification.copyAndSwitchSenderAndReceiver(applicationBPN);
+            switch (status) {
+                case ACKNOWLEDGED -> notification.acknowledge(notificationToSend);
+                case ACCEPTED -> notification.accept(reason, notificationToSend);
+                case DECLINED -> notification.decline(reason, notificationToSend);
+                case CLOSED -> notification.close(reason, notificationToSend);
+                default ->
+                        throw new QualityNotificationIllegalUpdate("Transition from status '%s' to status '%s' is not allowed for notification with id '%s'".formatted(notification.getNotificationStatus().name(), status, notification.getNotificationId()));
+            }
             log.info("::updateNotificationPublisher::notificationToSend {}", notificationToSend);
             notification.addNotification(notificationToSend);
             notificationsToSend.add(notificationToSend);
         });
 
         List<CompletableFuture<QualityNotificationMessage>> futures = notificationsToSend.stream()
-                .map(edcNotificationService::asyncNotificationMessageExecutor).filter(Objects::nonNull).toList();
+                .map(edcNotificationService::asyncNotificationMessageExecutor)
+                .filter(Objects::nonNull)
+                .toList();
         List<QualityNotificationMessage> sentMessages = futures.stream()
-                .map(CompletableFuture::join).toList();
+                .map(CompletableFuture::join)
+                .filter(Objects::nonNull)
+                .toList();
 
-        sentMessages.forEach(message -> {
-            switch (status) {
-                case ACKNOWLEDGED -> notification.acknowledge(message);
-                case ACCEPTED -> notification.accept(reason, message);
-                case DECLINED -> notification.decline(reason, message);
-                case CLOSED -> notification.close(reason, message);
-                default ->
-                        throw new QualityNotificationIllegalUpdate("Transition from status '%s' to status '%s' is not allowed for notification with id '%s'".formatted(notification.getNotificationStatus().name(), status, notification.getNotificationId()));
-            }
-        });
+        if (sentMessages.isEmpty()) {
+            throw new SendNotificationException("No Message was sent");
+        }
 
         return notification;
     }

--- a/tx-backend/src/test/java/org/eclipse/tractusx/traceability/qualitynotification/domain/service/EdcNotificationServiceImplTest.java
+++ b/tx-backend/src/test/java/org/eclipse/tractusx/traceability/qualitynotification/domain/service/EdcNotificationServiceImplTest.java
@@ -58,12 +58,6 @@ class EdcNotificationServiceImplTest {
     private InvestigationsEDCFacade edcFacade;
 
     @Mock
-    private InvestigationRepository investigationRepository;
-
-    @Mock
-    private AlertRepository alertRepository;
-
-    @Mock
     private DiscoveryService discoveryService;
 
     @Test
@@ -90,8 +84,6 @@ class EdcNotificationServiceImplTest {
 
         // then
         verify(edcFacade).startEdcTransfer(any(QualityNotificationMessage.class), eq(edcReceiverUrl), eq(edcSenderUrl));
-        verify(investigationRepository).updateQualityNotificationMessageEntity(notification);
-        verifyNoInteractions(alertRepository);
     }
 
     @Test
@@ -118,8 +110,6 @@ class EdcNotificationServiceImplTest {
 
         // then
         verify(edcFacade).startEdcTransfer(any(QualityNotificationMessage.class), eq(edcReceiverUrl), eq(edcSenderUrl));
-        verify(alertRepository).updateQualityNotificationMessageEntity(notification);
-        verifyNoInteractions(investigationRepository);
     }
 
     @Test
@@ -145,8 +135,6 @@ class EdcNotificationServiceImplTest {
 
         // then
         verify(edcFacade).startEdcTransfer(any(QualityNotificationMessage.class), eq(edcReceiverUrl), eq(edcSenderUrl));
-        verifyNoInteractions(alertRepository);
-        verifyNoInteractions(investigationRepository);
     }
 
     @Test
@@ -172,8 +160,6 @@ class EdcNotificationServiceImplTest {
 
         // then
         verify(edcFacade).startEdcTransfer(any(QualityNotificationMessage.class), eq(edcReceiverUrl), eq(edcSenderUrl));
-        verifyNoInteractions(alertRepository);
-        verifyNoInteractions(investigationRepository);
     }
 
     @Test
@@ -199,8 +185,6 @@ class EdcNotificationServiceImplTest {
 
         // then
         verify(edcFacade).startEdcTransfer(any(QualityNotificationMessage.class), eq(edcReceiverUrl), eq(edcSenderUrl));
-        verifyNoInteractions(alertRepository);
-        verifyNoInteractions(investigationRepository);
     }
 
     @Test
@@ -226,8 +210,6 @@ class EdcNotificationServiceImplTest {
 
         // then
         verify(edcFacade).startEdcTransfer(any(QualityNotificationMessage.class), eq(edcReceiverUrl), eq(edcSenderUrl));
-        verifyNoInteractions(alertRepository);
-        verifyNoInteractions(investigationRepository);
     }
 
 
@@ -254,8 +236,6 @@ class EdcNotificationServiceImplTest {
 
         // then
         verify(edcFacade).startEdcTransfer(any(QualityNotificationMessage.class), eq(edcReceiverUrl), eq(edcSenderUrl));
-        verifyNoInteractions(alertRepository);
-        verifyNoInteractions(investigationRepository);
     }
 
     @Test
@@ -281,8 +261,6 @@ class EdcNotificationServiceImplTest {
 
         // then
         verify(edcFacade).startEdcTransfer(any(QualityNotificationMessage.class), eq(edcReceiverUrl), eq(edcSenderUrl));
-        verifyNoInteractions(alertRepository);
-        verifyNoInteractions(investigationRepository);
     }
 
     @Test
@@ -308,8 +286,6 @@ class EdcNotificationServiceImplTest {
 
         // then
         verify(edcFacade).startEdcTransfer(any(QualityNotificationMessage.class), eq(edcReceiverUrl), eq(edcSenderUrl));
-        verifyNoInteractions(alertRepository);
-        verifyNoInteractions(investigationRepository);
     }
 
     @Test
@@ -335,7 +311,5 @@ class EdcNotificationServiceImplTest {
 
         // then
         verify(edcFacade).startEdcTransfer(any(QualityNotificationMessage.class), eq(edcReceiverUrl), eq(edcSenderUrl));
-        verifyNoInteractions(alertRepository);
-        verifyNoInteractions(investigationRepository);
     }
 }

--- a/tx-backend/src/test/java/org/eclipse/tractusx/traceability/qualitynotification/domain/service/NotificationPublisherServiceTest.java
+++ b/tx-backend/src/test/java/org/eclipse/tractusx/traceability/qualitynotification/domain/service/NotificationPublisherServiceTest.java
@@ -25,6 +25,7 @@ import org.eclipse.tractusx.traceability.bpn.domain.service.BpnRepository;
 import org.eclipse.tractusx.traceability.common.model.BPN;
 import org.eclipse.tractusx.traceability.common.properties.TraceabilityProperties;
 import org.eclipse.tractusx.traceability.qualitynotification.domain.base.InvestigationRepository;
+import org.eclipse.tractusx.traceability.qualitynotification.domain.base.exception.SendNotificationException;
 import org.eclipse.tractusx.traceability.qualitynotification.domain.base.model.QualityNotification;
 import org.eclipse.tractusx.traceability.qualitynotification.domain.base.model.QualityNotificationAffectedPart;
 import org.eclipse.tractusx.traceability.qualitynotification.domain.base.model.QualityNotificationMessage;
@@ -165,11 +166,8 @@ class NotificationPublisherServiceTest {
         when(traceabilityProperties.getBpn()).thenReturn(bpn);
         when(notificationsService.asyncNotificationMessageExecutor(any())).thenReturn(CompletableFuture.completedFuture(null));
 
-        // When
-        QualityNotification result = notificationPublisherService.approveNotification(investigation);
-
-        // Then
-        assertThat(result.getNotificationStatus()).isEqualTo(QualityNotificationStatus.CREATED);
+        // When/Then
+        assertThrows(SendNotificationException.class, () -> notificationPublisherService.approveNotification(investigation));
         verify(notificationsService).asyncNotificationMessageExecutor(any());
     }
 

--- a/tx-cucumber-tests/pom.xml
+++ b/tx-cucumber-tests/pom.xml
@@ -62,6 +62,11 @@ SPDX-License-Identifier: Apache-2.0
             <version>${commons-logging.version}</version>
         </dependency>
         <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-collections4</artifactId>
+            <version>${commons-collections.version}</version>
+        </dependency>
+        <dependency>
             <groupId>net.javacrumbs.json-unit</groupId>
             <artifactId>json-unit-assertj</artifactId>
             <version>${json-unit-assertj.version}</version>

--- a/tx-cucumber-tests/src/test/java/org/eclipse/tractusx/traceability/test/TraceabilityTestStepDefinition.java
+++ b/tx-cucumber-tests/src/test/java/org/eclipse/tractusx/traceability/test/TraceabilityTestStepDefinition.java
@@ -29,6 +29,7 @@ import io.cucumber.java.en.Then;
 import io.cucumber.java.en.When;
 import lombok.extern.slf4j.Slf4j;
 import org.awaitility.Duration;
+import org.eclipse.tractusx.traceability.test.exteption.MissingStepDefinitionException;
 import org.eclipse.tractusx.traceability.test.tooling.TraceXEnvironmentEnum;
 import org.eclipse.tractusx.traceability.test.tooling.rest.RestProvider;
 import org.eclipse.tractusx.traceability.test.tooling.rest.response.QualityNotificationResponse;
@@ -37,12 +38,14 @@ import org.hamcrest.Matchers;
 import qualitynotification.base.response.QualityNotificationIdResponse;
 
 import java.time.Instant;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
+import static org.apache.commons.lang3.ObjectUtils.isEmpty;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 import static org.eclipse.tractusx.traceability.test.tooling.NotificationTypeEnum.ALERT;
@@ -63,6 +66,7 @@ public class TraceabilityTestStepDefinition {
     private Long notificationID_TXB = null;
     private String notificationDescription = null;
     private List<AssetAsBuiltResponse> requestedAssets;
+    private List<String> testAssets;
 
 
     @ParameterType("TRACE_X_A|TRACE_X_B")
@@ -80,10 +84,18 @@ public class TraceabilityTestStepDefinition {
         restProvider.loginToEnvironment(environment);
     }
 
+    @Given("I use assets with ids {string}")
+    public void iUseAssetWithIds(String assetIds) {
+        testAssets = Arrays.stream(assetIds.split(",")).toList();
+    }
+
     @Given("I create quality investigation")
     public void iCreateQualityInvestigation(DataTable dataTable) {
         final Map<String, String> input = normalize(dataTable.asMap());
-        final String assetId = "urn:uuid:7eeeac86-7b69-444d-81e6-655d0f1513bd";
+
+        if (isEmpty(testAssets)) {
+            throw MissingStepDefinitionException.missingAssetDefinition();
+        }
 
         notificationDescription = wrapStringWithTimestamp(input.get("description"));
 
@@ -92,7 +104,7 @@ public class TraceabilityTestStepDefinition {
         final String severity = input.get("severity");
 
         final QualityNotificationIdResponse idResponse = restProvider.createNotification(
-                List.of(assetId),
+                testAssets,
                 notificationDescription,
                 targetDate,
                 severity,
@@ -106,18 +118,18 @@ public class TraceabilityTestStepDefinition {
     @When("I check, if quality investigation has proper values")
     public void iCheckIfQualityInvestigationHasProperValues(DataTable dataTable) {
         await()
-                .atMost(Duration.TWO_MINUTES)
+                .atMost(Duration.FIVE_MINUTES)
                 .pollInterval(1, TimeUnit.SECONDS)
                 .ignoreExceptions()
                 .until(() -> {
-                    try {
-                        QualityNotificationResponse result = restProvider.getNotification(getNotificationIdBasedOnEnv(), INVESTIGATION);
-                        NotificationValidator.assertHasFields(result, normalize(dataTable.asMap()));
-                        return true;
-                    } catch (AssertionError assertionError) {
-                        assertionError.printStackTrace();
-                        return false;
-                    }
+                            try {
+                                QualityNotificationResponse result = restProvider.getNotification(getNotificationIdBasedOnEnv(), INVESTIGATION);
+                                NotificationValidator.assertHasFields(result, normalize(dataTable.asMap()));
+                                return true;
+                            } catch (AssertionError assertionError) {
+                                assertionError.printStackTrace();
+                                return false;
+                            }
                         }
                 );
     }
@@ -151,10 +163,10 @@ public class TraceabilityTestStepDefinition {
     public void iCanSeeNotificationWasReceived() {
         System.out.println("searching for notificationDescription: " + notificationDescription);
         final QualityNotificationResponse notification = await()
-                .atMost(Duration.TWO_MINUTES)
+                .atMost(Duration.FIVE_MINUTES)
                 .pollInterval(1, TimeUnit.SECONDS)
                 .until(() -> {
-                    final List<QualityNotificationResponse> result = restProvider.getReceivedNotifications(INVESTIGATION);
+                            final List<QualityNotificationResponse> result = restProvider.getReceivedNotifications(INVESTIGATION);
                             result.stream().map(QualityNotificationResponse::getDescription).forEach(System.out::println);
                             return result.stream().filter(qn -> Objects.equals(qn.getDescription(), notificationDescription)).findFirst().orElse(null);
                         }, Matchers.notNullValue()
@@ -230,62 +242,14 @@ public class TraceabilityTestStepDefinition {
         requestedAssets.forEach(asset -> assertThat(ownerFilter).isEqualTo(asset.getOwner().toString()));
     }
 
-    @And("I create quality investigation with two parts")
-    public void iCreateQualityInvestigationWithTwoParts(DataTable dataTable) {
-        final Map<String, String> input = normalize(dataTable.asMap());
-        final String[] assetId = {
-                "urn:uuid:5205f736-8fc2-4585-b869-6bf36842369a",
-                "urn:uuid:7eeeac86-7b69-444d-81e6-655d0f1513bd"
-        };
-        notificationDescription = wrapStringWithTimestamp(input.get("description"));
-
-        final Instant targetDate = input.get("targetDate") == null ? null : Instant.parse(input.get("targetDate"));
-
-        final String severity = input.get("severity");
-
-        final QualityNotificationIdResponse idResponse = restProvider.createNotification(
-                List.of(assetId),
-                notificationDescription,
-                targetDate,
-                severity,
-                null,
-                INVESTIGATION
-        );
-        notificationID_TXA = idResponse.id();
-        assertThat(dataTable).isNotNull();
-    }
-
-    @And("I create quality alert with two parts")
-    public void iCreateQualityAlertWithTwoParts(DataTable dataTable) {
-        final Map<String, String> input = normalize(dataTable.asMap());
-        final String[] assetId = {
-                "urn:uuid:5205f736-8fc2-4585-b869-6bf36842369a",
-                "urn:uuid:7eeeac86-7b69-444d-81e6-655d0f1513bd"
-        };
-        notificationDescription = wrapStringWithTimestamp(input.get("description"));
-
-        final Instant targetDate = input.get("targetDate") == null ? null : Instant.parse(input.get("targetDate"));
-
-        final String severity = input.get("severity");
-
-        final QualityNotificationIdResponse idResponse = restProvider.createNotification(
-                List.of(assetId),
-                notificationDescription,
-                targetDate,
-                severity,
-                "BPNL00000003CNKC",
-                ALERT
-        );
-        notificationID_TXA = idResponse.id();
-        assertThat(dataTable).isNotNull();
-    }
-
-
     @Given("I create quality alert")
     public void iCreateQualityAlert(DataTable dataTable) {
 
         final Map<String, String> input = normalize(dataTable.asMap());
-        final String assetId = "urn:uuid:5205f736-8fc2-4585-b869-6bf36842369a";
+
+        if (isEmpty(testAssets)) {
+            throw MissingStepDefinitionException.missingAssetDefinition();
+        }
 
         notificationDescription = wrapStringWithTimestamp(input.get("description"));
 
@@ -294,7 +258,7 @@ public class TraceabilityTestStepDefinition {
         final String severity = input.get("severity");
 
         final QualityNotificationIdResponse idResponse = restProvider.createNotification(
-                List.of(assetId),
+                testAssets,
                 notificationDescription,
                 targetDate,
                 severity,
@@ -308,18 +272,18 @@ public class TraceabilityTestStepDefinition {
     @When("I check, if quality alert has proper values")
     public void iCheckIfQualityAlertHasProperValues(DataTable dataTable) {
         await()
-                .atMost(Duration.TWO_MINUTES)
+                .atMost(Duration.FIVE_MINUTES)
                 .pollInterval(1, TimeUnit.SECONDS)
                 .ignoreExceptions()
                 .until(() -> {
-                    try {
-                        QualityNotificationResponse result = restProvider.getNotification(getNotificationIdBasedOnEnv(), ALERT);
-                        NotificationValidator.assertHasFields(result, normalize(dataTable.asMap()));
-                        return true;
-                    } catch (AssertionError assertionError) {
-                        assertionError.printStackTrace();
-                        return false;
-                    }
+                            try {
+                                QualityNotificationResponse result = restProvider.getNotification(getNotificationIdBasedOnEnv(), ALERT);
+                                NotificationValidator.assertHasFields(result, normalize(dataTable.asMap()));
+                                return true;
+                            } catch (AssertionError assertionError) {
+                                assertionError.printStackTrace();
+                                return false;
+                            }
                         }
                 );
     }
@@ -335,7 +299,7 @@ public class TraceabilityTestStepDefinition {
     public void iCanSeeQualityAlertWasReceived() {
         System.out.println("searching for notificationDescription: " + notificationDescription);
         final QualityNotificationResponse notification = await()
-                .atMost(Duration.TWO_MINUTES)
+                .atMost(Duration.FIVE_MINUTES)
                 .pollInterval(1, TimeUnit.SECONDS)
                 .until(() -> {
                             final List<QualityNotificationResponse> result = restProvider.getReceivedNotifications(ALERT);

--- a/tx-cucumber-tests/src/test/java/org/eclipse/tractusx/traceability/test/exteption/MissingStepDefinitionException.java
+++ b/tx-cucumber-tests/src/test/java/org/eclipse/tractusx/traceability/test/exteption/MissingStepDefinitionException.java
@@ -1,0 +1,30 @@
+/********************************************************************************
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+package org.eclipse.tractusx.traceability.test.exteption;
+
+public class MissingStepDefinitionException extends RuntimeException {
+    private MissingStepDefinitionException(String message) {
+        super(message);
+    }
+
+    public static MissingStepDefinitionException missingAssetDefinition() {
+        return new MissingStepDefinitionException("Current step requires assets to be specified with following step: 'I use assets with ids {string}' where input param contains list of assetIds separated with ',' .");
+    }
+}

--- a/tx-cucumber-tests/src/test/resources/features/10_TRACEFOSS-1125.feature
+++ b/tx-cucumber-tests/src/test/resources/features/10_TRACEFOSS-1125.feature
@@ -36,6 +36,7 @@ Feature: ⭐[BE] User select severity for Quality Investigation
   @TRACEFOSS-1220 @TRACEFOSS-1920 @TEST-1217 @TRACEFOSS-1138 @TRACEFOSS-1139 @TRACEFOSS-1101 @TRACEFOSS-1673 @TEST-904 @INTEGRATION_TEST
   Scenario Outline: [BE] Check correct processing of severity in quality investigation
     When I am logged into TRACE_X_A application
+    When I use assets with ids 'urn:uuid:7eeeac86-7b69-444d-81e6-655d0f1513bd'
     And I create quality investigation
       | "severity"    | <severity>                        |
       | "description" | "Testing severity TRACEFOSS-1220" |

--- a/tx-cucumber-tests/src/test/resources/features/1_TRACEFOSS-1393.feature
+++ b/tx-cucumber-tests/src/test/resources/features/1_TRACEFOSS-1393.feature
@@ -17,6 +17,7 @@ Feature: ⭐ [BE][QUALITY_ALERTS] Create (POST) quality alerts (Rest API)
   @TRACEFOSS-1864 @TRACEFOSS-1920 @TEST-1217 @TEST-904 @TRACEFOSS-1673 @TRACEFOSS-1101 @INTEGRATION_TEST
   Scenario: [BE] Check correct processing of CANCELLATION of quality alerts
     When I am logged into TRACE_X_A application
+    When I use assets with ids 'urn:uuid:5205f736-8fc2-4585-b869-6bf36842369a'
     And I create quality alert
       | "severity"    | "MAJOR"                             |
       | "description" | "Testing ACCEPTANCE TRACEFOSS-1864" |
@@ -37,6 +38,7 @@ Feature: ⭐ [BE][QUALITY_ALERTS] Create (POST) quality alerts (Rest API)
   @TRACEFOSS-1863 @TRACEFOSS-1920 @TEST-1217 @TEST-904 @TRACEFOSS-1101 @TRACEFOSS-1673 @INTEGRATION_TEST
   Scenario: [BE] Check correct processing of CLOSURE of quality alerts
     When I am logged into TRACE_X_A application
+    When I use assets with ids 'urn:uuid:5205f736-8fc2-4585-b869-6bf36842369a'
     And I create quality alert
       | "severity"    | "MAJOR"                             |
       | "description" | "Testing ACCEPTANCE TRACEFOSS-1863" |
@@ -72,7 +74,8 @@ Feature: ⭐ [BE][QUALITY_ALERTS] Create (POST) quality alerts (Rest API)
   @TRACEFOSS-1670 @TRACEFOSS-1920 @TRACEFOSS-1101 @TRACEFOSS-1673 @TEST-904 @TEST-1217 @INTEGRATION_TEST
   Scenario: [BE] Check correct processing of several parts in quality alerts
     When I am logged into TRACE_X_A application
-    And I create quality alert with two parts
+    When I use assets with ids 'urn:uuid:7eeeac86-7b69-444d-81e6-655d0f1513bd,urn:uuid:5205f736-8fc2-4585-b869-6bf36842369a'
+    And I create quality alert
       | "severity"    | "MINOR"                           |
       | "description" | "Testing severity TRACEFOSS-1670" |
     Then I check, if quality alert has proper values
@@ -102,6 +105,7 @@ Feature: ⭐ [BE][QUALITY_ALERTS] Create (POST) quality alerts (Rest API)
   @TRACEFOSS-1547 @TRACEFOSS-1101 @TRACEFOSS-1920 @TRACEFOSS-1673 @TEST-904 @TEST-1217 @INTEGRATION_TEST
   Scenario: [BE] Check correct processing of bpn names in quality alerts
     When I am logged into TRACE_X_A application
+    When I use assets with ids 'urn:uuid:5205f736-8fc2-4585-b869-6bf36842369a'
     And I create quality alert
       | "description" | "Testing BPNs TRACEFOSS-1547" |
       | "severity"    | "MINOR"                       |
@@ -127,6 +131,7 @@ Feature: ⭐ [BE][QUALITY_ALERTS] Create (POST) quality alerts (Rest API)
   @TRACEFOSS-1546 @TRACEFOSS-1101 @TRACEFOSS-1920 @TRACEFOSS-1673 @TEST-904 @TEST-1217 @INTEGRATION_TEST
   Scenario: [BE] Check correct processing of targetDate = null in quality alerts
     When I am logged into TRACE_X_A application
+    When I use assets with ids 'urn:uuid:5205f736-8fc2-4585-b869-6bf36842369a'
     And I create quality alert
       | "severity"    | "MINOR"                                     |
       | "description" | "Testing without targetDate TRACEFOSS-1546" |
@@ -151,6 +156,7 @@ Feature: ⭐ [BE][QUALITY_ALERTS] Create (POST) quality alerts (Rest API)
   @TRACEFOSS-1545 @TRACEFOSS-1101 @TRACEFOSS-1920 @TRACEFOSS-1673 @TEST-904 @TEST-1217 @INTEGRATION_TEST
   Scenario: [BE] Check correct processing of DECLINATION of quality alerts
     When I am logged into TRACE_X_A application
+    When I use assets with ids 'urn:uuid:5205f736-8fc2-4585-b869-6bf36842369a'
     And I create quality alert
       | "severity"    | "MAJOR"                              |
       | "description" | "Testing DECLINATION TRACEFOSS-1545" |
@@ -187,6 +193,7 @@ Feature: ⭐ [BE][QUALITY_ALERTS] Create (POST) quality alerts (Rest API)
   @TRACEFOSS-1544 @TRACEFOSS-1101 @TRACEFOSS-1920 @TEST-904 @TRACEFOSS-1673 @TEST-1217 @INTEGRATION_TEST
   Scenario: [BE] Check correct processing of ACCEPTANCE of quality alerts
     When I am logged into TRACE_X_A application
+    When I use assets with ids 'urn:uuid:5205f736-8fc2-4585-b869-6bf36842369a'
     And I create quality alert
       | "severity"    | "MAJOR"                             |
       | "description" | "Testing ACCEPTANCE TRACEFOSS-1544" |
@@ -222,6 +229,7 @@ Feature: ⭐ [BE][QUALITY_ALERTS] Create (POST) quality alerts (Rest API)
   @TRACEFOSS-1543 @TRACEFOSS-1920 @TEST-904 @TRACEFOSS-1673 @TRACEFOSS-1101 @TEST-1217 @INTEGRATION_TEST
   Scenario: [BE] Check correct processing of targetDate in quality alerts
     When I am logged into TRACE_X_A application
+    When I use assets with ids 'urn:uuid:5205f736-8fc2-4585-b869-6bf36842369a'
     And I create quality alert
       | "severity"    | "MINOR"                             |
       | "description" | "Testing targetDate TRACEFOSS-1543" |
@@ -246,6 +254,7 @@ Feature: ⭐ [BE][QUALITY_ALERTS] Create (POST) quality alerts (Rest API)
   @TRACEFOSS-1539 @TRACEFOSS-1920 @TRACEFOSS-1101 @TRACEFOSS-1673 @TEST-904 @TEST-1217 @INTEGRATION_TEST
   Scenario Outline: [BE] Check correct processing of severity in quality alerts
     When I am logged into TRACE_X_A application
+    When I use assets with ids 'urn:uuid:5205f736-8fc2-4585-b869-6bf36842369a'
     And I create quality alert
       | "severity"    | <severity>                        |
       | "description" | "Testing severity TRACEFOSS-1539" |

--- a/tx-cucumber-tests/src/test/resources/features/2_TRACEFOSS-600.feature
+++ b/tx-cucumber-tests/src/test/resources/features/2_TRACEFOSS-600.feature
@@ -36,6 +36,7 @@ Feature: ⭐ [BE][QUALITY_ALERTS] Enable Quality Alerts
   @TRACEFOSS-1864 @TRACEFOSS-1920 @TEST-1217 @TEST-904 @TRACEFOSS-1673 @TRACEFOSS-1101 @INTEGRATION_TEST
   Scenario: [BE] Check correct processing of CANCELLATION of quality alerts
     When I am logged into TRACE_X_A application
+    When I use assets with ids 'urn:uuid:5205f736-8fc2-4585-b869-6bf36842369a'
     And I create quality alert
       | "severity"    | "MAJOR"                             |
       | "description" | "Testing ACCEPTANCE TRACEFOSS-1864" |
@@ -56,6 +57,7 @@ Feature: ⭐ [BE][QUALITY_ALERTS] Enable Quality Alerts
   @TRACEFOSS-1863 @TRACEFOSS-1920 @TEST-1217 @TEST-904 @TRACEFOSS-1101 @TRACEFOSS-1673 @INTEGRATION_TEST
   Scenario: [BE] Check correct processing of CLOSURE of quality alerts
     When I am logged into TRACE_X_A application
+    When I use assets with ids 'urn:uuid:5205f736-8fc2-4585-b869-6bf36842369a'
     And I create quality alert
       | "severity"    | "MAJOR"                             |
       | "description" | "Testing ACCEPTANCE TRACEFOSS-1863" |
@@ -90,6 +92,7 @@ Feature: ⭐ [BE][QUALITY_ALERTS] Enable Quality Alerts
   @TRACEFOSS-1547 @TRACEFOSS-1101 @TRACEFOSS-1920 @TRACEFOSS-1673 @TEST-904 @TEST-1217 @INTEGRATION_TEST
   Scenario: [BE] Check correct processing of bpn names in quality alerts
     When I am logged into TRACE_X_A application
+    When I use assets with ids 'urn:uuid:5205f736-8fc2-4585-b869-6bf36842369a'
     And I create quality alert
       | "description" | "Testing BPNs TRACEFOSS-1547" |
       | "severity"    | "MINOR"                       |
@@ -115,6 +118,7 @@ Feature: ⭐ [BE][QUALITY_ALERTS] Enable Quality Alerts
   @TRACEFOSS-1546 @TRACEFOSS-1101 @TRACEFOSS-1920 @TRACEFOSS-1673 @TEST-904 @TEST-1217 @INTEGRATION_TEST
   Scenario: [BE] Check correct processing of targetDate = null in quality alerts
     When I am logged into TRACE_X_A application
+    When I use assets with ids 'urn:uuid:5205f736-8fc2-4585-b869-6bf36842369a'
     And I create quality alert
       | "severity"    | "MINOR"                                     |
       | "description" | "Testing without targetDate TRACEFOSS-1546" |
@@ -139,6 +143,7 @@ Feature: ⭐ [BE][QUALITY_ALERTS] Enable Quality Alerts
   @TRACEFOSS-1545 @TRACEFOSS-1101 @TRACEFOSS-1920 @TRACEFOSS-1673 @TEST-904 @TEST-1217 @INTEGRATION_TEST
   Scenario: [BE] Check correct processing of DECLINATION of quality alerts
     When I am logged into TRACE_X_A application
+    When I use assets with ids 'urn:uuid:5205f736-8fc2-4585-b869-6bf36842369a'
     And I create quality alert
       | "severity"    | "MAJOR"                              |
       | "description" | "Testing DECLINATION TRACEFOSS-1545" |
@@ -175,6 +180,7 @@ Feature: ⭐ [BE][QUALITY_ALERTS] Enable Quality Alerts
   @TRACEFOSS-1544 @TRACEFOSS-1101 @TRACEFOSS-1920 @TEST-904 @TRACEFOSS-1673 @TEST-1217 @INTEGRATION_TEST
   Scenario: [BE] Check correct processing of ACCEPTANCE of quality alerts
     When I am logged into TRACE_X_A application
+    When I use assets with ids 'urn:uuid:5205f736-8fc2-4585-b869-6bf36842369a'
     And I create quality alert
       | "severity"    | "MAJOR"                             |
       | "description" | "Testing ACCEPTANCE TRACEFOSS-1544" |
@@ -210,6 +216,7 @@ Feature: ⭐ [BE][QUALITY_ALERTS] Enable Quality Alerts
   @TRACEFOSS-1543 @TRACEFOSS-1920 @TEST-904 @TRACEFOSS-1673 @TRACEFOSS-1101 @TEST-1217 @INTEGRATION_TEST
   Scenario: [BE] Check correct processing of targetDate in quality alerts
     When I am logged into TRACE_X_A application
+    When I use assets with ids 'urn:uuid:5205f736-8fc2-4585-b869-6bf36842369a'
     And I create quality alert
       | "severity"    | "MINOR"                             |
       | "description" | "Testing targetDate TRACEFOSS-1543" |
@@ -234,6 +241,7 @@ Feature: ⭐ [BE][QUALITY_ALERTS] Enable Quality Alerts
   @TRACEFOSS-1539 @TRACEFOSS-1920 @TRACEFOSS-1101 @TRACEFOSS-1673 @TEST-904 @TEST-1217 @INTEGRATION_TEST
   Scenario Outline: [BE] Check correct processing of severity in quality alerts
     When I am logged into TRACE_X_A application
+    When I use assets with ids 'urn:uuid:5205f736-8fc2-4585-b869-6bf36842369a'
     And I create quality alert
       | "severity"    | <severity>                        |
       | "description" | "Testing severity TRACEFOSS-1539" |

--- a/tx-cucumber-tests/src/test/resources/features/3_TRACEFOSS-936.feature
+++ b/tx-cucumber-tests/src/test/resources/features/3_TRACEFOSS-936.feature
@@ -27,6 +27,7 @@ Feature: ⭐[BE] Include reason for receiver and sender investigations
   @TRACEFOSS-1862 @TRACEFOSS-1920 @TEST-1217 @TEST-904 @TRACEFOSS-1101 @TRACEFOSS-1673 @INTEGRATION_TEST
   Scenario: [BE] Check correct processing of CANCELLATION of quality investigation
     When I am logged into TRACE_X_A application
+    When I use assets with ids 'urn:uuid:7eeeac86-7b69-444d-81e6-655d0f1513bd'
     And I create quality investigation
       | "severity"    | "MAJOR"                             |
       | "description" | "Testing ACCEPTANCE TRACEFOSS-1862" |
@@ -46,6 +47,7 @@ Feature: ⭐[BE] Include reason for receiver and sender investigations
   @TRACEFOSS-1861 @TRACEFOSS-1920 @TEST-1217 @TRACEFOSS-1101 @TEST-904 @TRACEFOSS-1673 @INTEGRATION_TEST
   Scenario: [BE] Check correct processing of CLOSURE of quality investigation
     When I am logged into TRACE_X_A application
+    When I use assets with ids 'urn:uuid:7eeeac86-7b69-444d-81e6-655d0f1513bd'
     And I create quality investigation
       | "severity"    | "MAJOR"                             |
       | "description" | "Testing ACCEPTANCE TRACEFOSS-1861" |
@@ -81,6 +83,7 @@ Feature: ⭐[BE] Include reason for receiver and sender investigations
   @TRACEFOSS-1223 @TRACEFOSS-1920 @TRACEFOSS-1673 @TEST-1217 @TRACEFOSS-1139 @TEST-904 @TRACEFOSS-1138 @TRACEFOSS-1101 @INTEGRATION_TEST
   Scenario: [BE] Check correct processing of DECLINATION of quality investigation
     When I am logged into TRACE_X_A application
+    When I use assets with ids 'urn:uuid:7eeeac86-7b69-444d-81e6-655d0f1513bd'
     And I create quality investigation
       | "severity"    | "MAJOR"                              |
       | "description" | "Testing DECLINATION TRACEFOSS-1223" |
@@ -116,6 +119,7 @@ Feature: ⭐[BE] Include reason for receiver and sender investigations
   @TRACEFOSS-1222 @TRACEFOSS-1920 @TRACEFOSS-1673 @TEST-1217 @TRACEFOSS-1139 @TRACEFOSS-1138 @TRACEFOSS-1101 @TEST-904 @INTEGRATION_TEST
   Scenario: [BE] Check correct processing of ACCEPTANCE of quality investigation
     When I am logged into TRACE_X_A application
+    When I use assets with ids 'urn:uuid:7eeeac86-7b69-444d-81e6-655d0f1513bd'
     And I create quality investigation
       | "severity"    | "MAJOR"                             |
       | "description" | "Testing ACCEPTANCE TRACEFOSS-1222" |

--- a/tx-cucumber-tests/src/test/resources/features/4_TRACEFOSS-938.feature
+++ b/tx-cucumber-tests/src/test/resources/features/4_TRACEFOSS-938.feature
@@ -38,6 +38,7 @@ Feature: ⭐[TEST] Update Quality Investigation (over EDC)
   @TRACEFOSS-1862 @TRACEFOSS-1920 @TEST-1217 @TEST-904 @TRACEFOSS-1101 @TRACEFOSS-1673 @INTEGRATION_TEST
   Scenario: [BE] Check correct processing of CANCELLATION of quality investigation
     When I am logged into TRACE_X_A application
+    When I use assets with ids 'urn:uuid:7eeeac86-7b69-444d-81e6-655d0f1513bd'
     And I create quality investigation
       | "severity"    | "MAJOR"                             |
       | "description" | "Testing ACCEPTANCE TRACEFOSS-1862" |
@@ -57,6 +58,7 @@ Feature: ⭐[TEST] Update Quality Investigation (over EDC)
   @TRACEFOSS-1861 @TRACEFOSS-1920 @TEST-1217 @TRACEFOSS-1101 @TEST-904 @TRACEFOSS-1673 @INTEGRATION_TEST
   Scenario: [BE] Check correct processing of CLOSURE of quality investigation
     When I am logged into TRACE_X_A application
+    When I use assets with ids 'urn:uuid:7eeeac86-7b69-444d-81e6-655d0f1513bd'
     And I create quality investigation
       | "severity"    | "MAJOR"                             |
       | "description" | "Testing ACCEPTANCE TRACEFOSS-1861" |
@@ -92,6 +94,7 @@ Feature: ⭐[TEST] Update Quality Investigation (over EDC)
   @TRACEFOSS-1223 @TRACEFOSS-1920 @TRACEFOSS-1673 @TEST-1217 @TRACEFOSS-1139 @TEST-904 @TRACEFOSS-1138 @TRACEFOSS-1101 @INTEGRATION_TEST
   Scenario: [BE] Check correct processing of DECLINATION of quality investigation
     When I am logged into TRACE_X_A application
+    When I use assets with ids 'urn:uuid:7eeeac86-7b69-444d-81e6-655d0f1513bd'
     And I create quality investigation
       | "severity"    | "MAJOR"                              |
       | "description" | "Testing DECLINATION TRACEFOSS-1223" |
@@ -127,6 +130,7 @@ Feature: ⭐[TEST] Update Quality Investigation (over EDC)
   @TRACEFOSS-1222 @TRACEFOSS-1920 @TRACEFOSS-1673 @TEST-1217 @TRACEFOSS-1139 @TRACEFOSS-1138 @TRACEFOSS-1101 @TEST-904 @INTEGRATION_TEST
   Scenario: [BE] Check correct processing of ACCEPTANCE of quality investigation
     When I am logged into TRACE_X_A application
+    When I use assets with ids 'urn:uuid:7eeeac86-7b69-444d-81e6-655d0f1513bd'
     And I create quality investigation
       | "severity"    | "MAJOR"                             |
       | "description" | "Testing ACCEPTANCE TRACEFOSS-1222" |

--- a/tx-cucumber-tests/src/test/resources/features/5_TRACEFOSS-1625.feature
+++ b/tx-cucumber-tests/src/test/resources/features/5_TRACEFOSS-1625.feature
@@ -21,7 +21,8 @@ Feature: [BE][FE]Handling of several parts in one quality alert
   @TRACEFOSS-1670 @TRACEFOSS-1920 @TRACEFOSS-1101 @TRACEFOSS-1673 @TEST-904 @TEST-1217 @INTEGRATION_TEST
   Scenario: [BE] Check correct processing of several parts in quality alerts
     When I am logged into TRACE_X_A application
-    And I create quality alert with two parts
+    When I use assets with ids 'urn:uuid:7eeeac86-7b69-444d-81e6-655d0f1513bd,urn:uuid:5205f736-8fc2-4585-b869-6bf36842369a'
+    And I create quality alert
       | "severity"    | "MINOR"                           |
       | "description" | "Testing severity TRACEFOSS-1670" |
     Then I check, if quality alert has proper values

--- a/tx-cucumber-tests/src/test/resources/features/6_TRACEFOSS-382.feature
+++ b/tx-cucumber-tests/src/test/resources/features/6_TRACEFOSS-382.feature
@@ -34,7 +34,8 @@ Feature: Create Request for quality investigation / store in queue
   @TRACEFOSS-1652 @TRACEFOSS-1101 @INTEGRATION_TEST
   Scenario: [BE] Check correct processing of several parts in quality investigation
     When I am logged into TRACE_X_A application
-    And I create quality investigation with two parts
+    When I use assets with ids 'urn:uuid:7eeeac86-7b69-444d-81e6-655d0f1513bd,urn:uuid:5205f736-8fc2-4585-b869-6bf36842369a'
+    And I create quality investigation
       | "severity"    | "MINOR"                           |
       | "description" | "Testing severity TRACEFOSS-1652" |
     Then I check, if quality investigation has proper values

--- a/tx-cucumber-tests/src/test/resources/features/7_TRACEFOSS-1090.feature
+++ b/tx-cucumber-tests/src/test/resources/features/7_TRACEFOSS-1090.feature
@@ -23,6 +23,7 @@ Feature: 🪓⭐[BE] Add information to notification inbox
   @TRACEFOSS-1344 @TRACEFOSS-1920 @TRACEFOSS-1101 @TRACEFOSS-1138 @TRACEFOSS-1673 @TEST-1217 @TRACEFOSS-1139 @TEST-904 @INTEGRATION_TEST
   Scenario: [BE] Check correct processing of bpn names in quality investigation
     When I am logged into TRACE_X_A application
+    When I use assets with ids 'urn:uuid:7eeeac86-7b69-444d-81e6-655d0f1513bd'
     And I create quality investigation
       | "description" | "Testing BPNs TRACEFOSS-1344" |
       | "severity"    | "MINOR"                       |

--- a/tx-cucumber-tests/src/test/resources/features/8_TRACEFOSS-608.feature
+++ b/tx-cucumber-tests/src/test/resources/features/8_TRACEFOSS-608.feature
@@ -13,6 +13,7 @@ Feature: ⭐[TEST] [BE] Set and show notification target date
   @TRACEFOSS-1247 @TRACEFOSS-1920 @TEST-1217 @TRACEFOSS-1139 @TEST-904 @TRACEFOSS-1673 @TRACEFOSS-1138 @TRACEFOSS-1101 @INTEGRATION_TEST
   Scenario: [BE] Check correct processing of targetDate = null in quality investigation
     When I am logged into TRACE_X_A application
+    When I use assets with ids 'urn:uuid:7eeeac86-7b69-444d-81e6-655d0f1513bd'
     And I create quality investigation
       | "severity"    | "MINOR"                                     |
       | "description" | "Testing without targetDate TRACEFOSS-1247" |
@@ -36,6 +37,7 @@ Feature: ⭐[TEST] [BE] Set and show notification target date
   @TRACEFOSS-1216 @TRACEFOSS-1920 @TEST-1217 @TRACEFOSS-1139 @TRACEFOSS-1673 @TRACEFOSS-1138 @TRACEFOSS-1101 @TEST-904 @INTEGRATION_TEST
   Scenario: [BE] Check correct processing of targetDate in quality investigation
     When I am logged into TRACE_X_A application
+    When I use assets with ids 'urn:uuid:7eeeac86-7b69-444d-81e6-655d0f1513bd'
     And I create quality investigation
       | "severity"    | "MINOR"                             |
       | "description" | "Testing targetDate TRACEFOSS-1216" |


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->
### Added
- Separation of auto complete mechanism (selected / searched elements)
- Added new step definition for cucumber tests "I use assets with ids {string}" allowing to specify assets used for notification creation

### Changed
- Cucumber test steps for creating notifications no longer support default assetId when no asset is provided with previous step
- Upgraded the Upload_Testdata job in Argo Workflow to fix bugs

### Removed
- Removed Cucumber tests steps for creating alerts with two parts as new step definition is enough for the same feature

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [X] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [X] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
