### PR TITLE
Version bumps 

### DIFF
--- a/.github/workflows/argo.yml
+++ b/.github/workflows/argo.yml
@@ -44,7 +44,7 @@ on:
         type: choice
         description: Do you want a Hard Refresh? (+5min execution time)
         required: true
-        options: 
+        options:
         - Yes
         - No
 
@@ -83,7 +83,7 @@ jobs:
   test_input:
    runs-on: ubuntu-latest
    steps:
-   
+
       - name: Checkout-Repository
         uses: actions/checkout@v4
 
@@ -92,19 +92,19 @@ jobs:
           ARGO_TOKEN=$(jq -r '.inputs.argo_token' $GITHUB_EVENT_PATH)
           echo ::add-mask::$ARGO_TOKEN
           echo ARGO_TOKEN=$ARGO_TOKEN >> $GITHUB_ENV
-          
+
       - name: Check Testdata Version Format
         run: |
          if [[ ! "${{ github.event.inputs.testdata_version }}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
           echo "Invalid Testdata Version format. Please use X.X.X, e.g., 1.1.12"
           exit 1
          fi
-         
+
       - name: Check Argo Token
         run: |
-         
+
            source ./.github/argo/argo_config.sh
-           
+
            if [ "${{ github.event.inputs.environment }}" == "Dev/Test" ]; then
               resources="${DEV_TEST_RESOURCES[2]}"
             elif [ "${{ github.event.inputs.environment }}" == "E2E-A/E2E-B" ]; then
@@ -121,8 +121,8 @@ jobs:
             echo "Argo Token is invalid."
             exit 1
            fi
-            
-      
+
+
   print_environment:
    needs: test_input
    runs-on: ubuntu-latest
@@ -131,7 +131,7 @@ jobs:
         run: |
           echo "### inputs" >> $GITHUB_STEP_SUMMARY
           echo "- environment: ${{ github.event.inputs.environment }}" >> $GITHUB_STEP_SUMMARY
-          
+
 
   hard_refresh_environment:
    needs: print_environment
@@ -159,7 +159,7 @@ jobs:
            elif [ "${{ github.event.inputs.environment }}" == "int-a/int-b" ]; then
               resources=("${INT_RESOURCES[@]}")
            fi
-          
+
            for resource in "${resources[@]}"; do
              curl -X GET -H "Authorization: Bearer ${{ env.ARGO_TOKEN }}" "$resource?refresh=hard&appNamespace=argocd"
            done
@@ -345,15 +345,15 @@ jobs:
     needs: test_state
     runs-on: ubuntu-latest
     steps:
-    
+
      - name: Checkout code
        uses: actions/checkout@v4
-            
+
      - name: Set up Python
-       uses: actions/setup-python@v4
+       uses: actions/setup-python@v5
        with:
         python-version: '3.11'
-    
+
      - name: Upload testdata
        run: |
         python -m pip install requests

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -73,7 +73,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: '17'
           distribution: 'temurin'

--- a/.github/workflows/dependencies.yaml
+++ b/.github/workflows/dependencies.yaml
@@ -31,7 +31,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up JDK
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: 17
           distribution: 'temurin'

--- a/.github/workflows/dependency-check.yml
+++ b/.github/workflows/dependency-check.yml
@@ -33,7 +33,7 @@ jobs:
       pull-requests: write
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-java@v3
+      - uses: actions/setup-java@v4
         with:
           java-version: '${{ env.JAVA_VERSION }}'
           distribution: 'temurin'

--- a/.github/workflows/docker-image-main_backend.yml
+++ b/.github/workflows/docker-image-main_backend.yml
@@ -41,7 +41,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-java@v3
+      - uses: actions/setup-java@v4
         with:
           java-version: '${{ env.JAVA_VERSION }}'
           distribution: 'temurin'

--- a/.github/workflows/docker-image-tag-release.yaml
+++ b/.github/workflows/docker-image-tag-release.yaml
@@ -108,7 +108,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-java@v3
+      - uses: actions/setup-java@v4
         with:
           java-version: '${{ env.JAVA_VERSION }}'
           distribution: 'temurin'

--- a/.github/workflows/eclipse-dash.yml
+++ b/.github/workflows/eclipse-dash.yml
@@ -61,7 +61,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: '17'
           distribution: 'temurin'

--- a/.github/workflows/publish-documentation.yaml
+++ b/.github/workflows/publish-documentation.yaml
@@ -42,7 +42,7 @@ jobs:
         uses: ts-graphviz/setup-graphviz@v1
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: '17'
           distribution: 'temurin'

--- a/.github/workflows/pull-request_backend.yml
+++ b/.github/workflows/pull-request_backend.yml
@@ -34,7 +34,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-java@v3
+      - uses: actions/setup-java@v4
         with:
           java-version: '${{ env.JAVA_VERSION }}'
           distribution: 'temurin'
@@ -86,7 +86,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - uses: actions/setup-java@v3
+      - uses: actions/setup-java@v4
         with:
           java-version: '${{ env.JAVA_VERSION }}'
           distribution: 'temurin'

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -17,42 +17,42 @@ jobs:
         run: echo HELM_VERSION=$(cat charts/traceability-foss/CHANGELOG.md | sed -n 's/.*\[\([0-9]\+\.[0-9]\+\.[0-9]\+\)\].*/\1/p' | head -n 1) >> $GITHUB_ENV
 
       - name: Update Chart.yaml appVersion
-        uses: mikefarah/yq@v4.40.2
+        uses: mikefarah/yq@v4.40.5
         with:
           cmd: yq -i eval '.appVersion = "${{ github.ref_name }}"' charts/traceability-foss/Chart.yaml
 
       - name: Update Chart.yaml version
-        uses: mikefarah/yq@v4.40.2
+        uses: mikefarah/yq@v4.40.5
         with:
           cmd: yq -i eval '.version = "${{ env.HELM_VERSION }}"' charts/traceability-foss/Chart.yaml
 
       - name: Update frontend dependency version in Chart.yaml
-        uses: mikefarah/yq@v4.40.2
+        uses: mikefarah/yq@v4.40.5
         with:
           cmd: yq -i eval '.dependencies[0].version = "${{ env.HELM_VERSION }}"' charts/traceability-foss/Chart.yaml
 
       - name: Update backend dependency version in Chart.yaml
-        uses: mikefarah/yq@v4.40.2
+        uses: mikefarah/yq@v4.40.5
         with:
           cmd: yq -i eval '.dependencies[1].version = "${{ env.HELM_VERSION }}"' charts/traceability-foss/Chart.yaml
 
       - name: Update frontend version in frontend/Chart.yaml
-        uses: mikefarah/yq@v4.40.2
+        uses: mikefarah/yq@v4.40.5
         with:
           cmd: yq -i eval '.version = "${{ env.HELM_VERSION }}"' charts/traceability-foss/charts/frontend/Chart.yaml
 
       - name: Update frontend appVersion in frontend/Chart.yaml
-        uses: mikefarah/yq@v4.40.2
+        uses: mikefarah/yq@v4.40.5
         with:
           cmd: yq -i eval '.appVersion = "${{ github.ref_name }}"' charts/traceability-foss/charts/frontend/Chart.yaml
 
       - name: Update backend version in backend/Chart.yaml
-        uses: mikefarah/yq@v4.40.2
+        uses: mikefarah/yq@v4.40.5
         with:
           cmd: yq -i eval '.version = "${{ env.HELM_VERSION }}"' charts/traceability-foss/charts/backend/Chart.yaml
 
       - name: Update backend appVersion in frontend/Chart.yaml
-        uses: mikefarah/yq@v4.40.2
+        uses: mikefarah/yq@v4.40.5
         with:
           cmd: yq -i eval '.appVersion = "${{ github.ref_name }}"' charts/traceability-foss/charts/backend/Chart.yaml
 

--- a/.github/workflows/sonar-scan-backend.yml
+++ b/.github/workflows/sonar-scan-backend.yml
@@ -38,7 +38,7 @@ jobs:
         with:
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
 
-      - uses: actions/setup-java@v3
+      - uses: actions/setup-java@v4
         with:
           java-version: '${{ env.JAVA_VERSION }}'
           distribution: 'temurin'

--- a/.github/workflows/spotbugs.yml
+++ b/.github/workflows/spotbugs.yml
@@ -47,7 +47,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: '17'
           distribution: 'temurin'

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -72,7 +72,7 @@ jobs:
         run: docker build -t localhost:5000/traceability-foss:fe_${{ github.sha }} -f ./frontend/Dockerfile .
 
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@0.14.0
+        uses: aquasecurity/trivy-action@0.16.0
         with:
           image-ref: 'localhost:5000/traceability-foss:fe_${{ github.sha }}'
           format: "sarif"
@@ -131,7 +131,7 @@ jobs:
           ref: ${{needs.prepare-env.outputs.check_sha}}
 
       - name: Run Trivy vulnerability scanner in repo mode
-        uses: aquasecurity/trivy-action@0.14.0
+        uses: aquasecurity/trivy-action@0.16.0
         with:
           scan-type: "config"
           hide-progress: false
@@ -162,7 +162,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - uses: actions/setup-java@v3
+      - uses: actions/setup-java@v4
         with:
           java-version: '${{ env.JAVA_VERSION }}'
           distribution: 'temurin'
@@ -176,7 +176,7 @@ jobs:
           tags: localhost:5000/traceability-foss:trivy
 
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@0.14.0
+        uses: aquasecurity/trivy-action@0.16.0
         with:
           image-ref: localhost:5000/traceability-foss:trivy
           trivyignores: "./.github/workflows/.trivyignore"

--- a/.github/workflows/veracode_backend.yml
+++ b/.github/workflows/veracode_backend.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - uses: actions/setup-java@v3
+      - uses: actions/setup-java@v4
         with:
           java-version: '${{ env.JAVA_VERSION }}'
           distribution: 'temurin'

--- a/.github/workflows/xray-cucumber.yaml
+++ b/.github/workflows/xray-cucumber.yaml
@@ -30,7 +30,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: '17'
           distribution: 'temurin'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres
 to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [UNRELEASED - DD.MM.YYYY]
+### Added
+### Changed
+- Restricted datefield on investigation creation to be only clickable and not editable
 
 ## [10.0.0 - 12.12.2024]
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Added
 ### Changed
 - Restricted datefield on investigation creation to be only clickable and not editable
+- bump aquasecurity/trivy-action from 0.14.0 to 0.16.0
+- bump actions/setup-python from 4 to 5
+- bump mikefarah/yq from 4.40.2 to 4.40.5
+- bump actions/setup-java from 3 to 4
+- bump org.apache.maven.plugins:maven-jxr-plugin from 3.3.0 to 3.3.1
+- bump org.apache.maven.plugins:maven-checkstyle-plugin from 3.3.0 to 3.3.1
+- bump schedlock.version from 5.9.1 to 5.10.0
 
 ## [10.0.0 - 12.12.2024]
 ### Added

--- a/frontend/src/app/modules/shared/components/dateTime/dateTime.component.html
+++ b/frontend/src/app/modules/shared/components/dateTime/dateTime.component.html
@@ -20,7 +20,7 @@ SPDX-License-Identifier: Apache-2.0
 -->
 
 <div class="flex flex-col">
-  <mat-form-field>
+  <mat-form-field tabindex=0>
     <mat-label>{{ label }}</mat-label>
     <input
       #inputElement
@@ -29,6 +29,8 @@ SPDX-License-Identifier: Apache-2.0
       [attr.max]="maxDate || null"
       [formControl]="control"
       [errorStateMatcher]="matcher"
+      onkeydown="return false"
+      (click)="openDatePicker(inputElement)"
       matInput
       type="datetime-local"
       placeholder="start date"

--- a/frontend/src/app/modules/shared/components/dateTime/dateTime.component.ts
+++ b/frontend/src/app/modules/shared/components/dateTime/dateTime.component.ts
@@ -46,4 +46,8 @@ export class DateTimeComponent extends BaseInputComponent<Date> {
   constructor(@Inject(Injector) injector: Injector, staticIdService: StaticIdService) {
     super(injector, staticIdService);
   }
+
+  openDatePicker(element: any): void{
+      element.showPicker();
+  }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -48,8 +48,9 @@ SPDX-License-Identifier: Apache-2.0
         <start-class>org.eclipse.tractusx.traceability.TraceabilityApplication</start-class>
 
         <!-- versions for Maven plugin -->
+        <maven-jxr-plugin.version>3.3.1</maven-jxr-plugin.version>
         <ascii-doctor.maven.plugin.version>2.2.4</ascii-doctor.maven.plugin.version>
-        <checkstyle-plugin.version>3.3.0</checkstyle-plugin.version>
+        <checkstyle-plugin.version>3.3.1</checkstyle-plugin.version>
         <compiler-plugin.version>3.11.0</compiler-plugin.version>
         <findsecbugs-plugin.version>1.12.0</findsecbugs-plugin.version>
         <install-plugin.version>3.1.1</install-plugin.version>
@@ -74,7 +75,7 @@ SPDX-License-Identifier: Apache-2.0
         <jakarta-ws-rs.version>3.1.0</jakarta-ws-rs.version>
         <jruby.version>9.4.3.0</jruby.version>
         <resilience4j.version>2.0.2</resilience4j.version>
-        <schedlock.version>5.9.1</schedlock.version>
+        <schedlock.version>5.10.0</schedlock.version>
         <spring-cloud.version>2022.0.3</spring-cloud.version>
         <jetbrains-annotation.version>24.0.1</jetbrains-annotation.version>
         <feign-form.version>3.8.0</feign-form.version>

--- a/tx-backend/pom.xml
+++ b/tx-backend/pom.xml
@@ -568,7 +568,7 @@ SPDX-License-Identifier: Apache-2.0
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jxr-plugin</artifactId>
-                <version>3.3.0</version>
+                <version>${maven-jxr-plugin.version}</version>
             </plugin>
         </plugins>
     </reporting>


### PR DESCRIPTION

## Description

### Changed
- Restricted datefield on investigation creation to be only clickable and not editable
- bump aquasecurity/trivy-action from 0.14.0 to 0.16.0
- bump actions/setup-python from 4 to 5
- bump mikefarah/yq from 4.40.2 to 4.40.5
- bump actions/setup-java from 3 to 4
- bump org.apache.maven.plugins:maven-jxr-plugin from 3.3.0 to 3.3.1
- bump org.apache.maven.plugins:maven-checkstyle-plugin from 3.3.0 to 3.3.1
- bump schedlock.version from 5.9.1 to 5.10.0