### PR TITLE
Security bumps 

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -80,7 +80,7 @@ jobs:
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v2
+        uses: github/codeql-action/init@v3
         with:
           languages: ${{ matrix.language }}
           # If you wish to specify custom queries, you can do so here or in a config file.
@@ -101,7 +101,7 @@ jobs:
       # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
       # If this step fails, then you should remove it and run the build manually (see below)
       #- name: Autobuild
-      #  uses: github/codeql-action/autobuild@v2
+      #  uses: github/codeql-action/autobuild@v3
 
       # ℹ️ Command-line programs to run using the OS shell.
       # 📚 https://git.io/JvXDl
@@ -115,4 +115,4 @@ jobs:
           mvn clean package -pl tx-models,tx-backend --batch-mode -DskipTests
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v2
+        uses: github/codeql-action/analyze@v3

--- a/.github/workflows/e2e-tests-xray_frontend.yml
+++ b/.github/workflows/e2e-tests-xray_frontend.yml
@@ -90,7 +90,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Download the cypress/e2e folder
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: cypress - e2e
           path: frontend/cypress/e2e
@@ -152,7 +152,7 @@ jobs:
  #       uses: actions/checkout@v4
 #
  #     - name: Download the cypress/e2e folder
- #       uses: actions/download-artifact@v3
+ #       uses: actions/download-artifact@v4
  #       with:
  #         name: cypress - e2e
  #         path: frontend/cypress/e2e
@@ -202,7 +202,7 @@ jobs:
  #       uses: actions/checkout@v4
 #
  #     - name: Download the cypress/e2e folder
- #       uses: actions/download-artifact@v3
+ #       uses: actions/download-artifact@v4
  #       with:
  #         name: cypress - e2e
  #         path: frontend/cypress/e2e

--- a/.github/workflows/kics.yml
+++ b/.github/workflows/kics.yml
@@ -77,7 +77,7 @@ jobs:
       # Upload findings to GitHub Advanced Security Dashboard
       - name: Upload SARIF file for GitHub Advanced Security Dashboard
         if: always()
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: kicsResults/results.sarif
 
@@ -122,7 +122,7 @@ jobs:
       # Upload findings to GitHub Advanced Security Dashboard
       - name: Upload SARIF file for GitHub Advanced Security Dashboard
         if: always()
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: kicsResults/results.sarif
 

--- a/.github/workflows/pull_request_issue.yml
+++ b/.github/workflows/pull_request_issue.yml
@@ -51,7 +51,7 @@ jobs:
           fi
 
       - name: Update Pull Request
-        uses: actions/github-script@v5
+        uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -72,7 +72,7 @@ jobs:
         run: docker build -t localhost:5000/traceability-foss:fe_${{ github.sha }} -f ./frontend/Dockerfile .
 
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@0.16.0
+        uses: aquasecurity/trivy-action@0.16.1
         with:
           image-ref: 'localhost:5000/traceability-foss:fe_${{ github.sha }}'
           format: "sarif"
@@ -81,7 +81,7 @@ jobs:
           severity: 'CRITICAL,HIGH'
 
       - name: Upload Trivy scan results to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: 'trivy-results.sarif'
 
@@ -131,7 +131,7 @@ jobs:
           ref: ${{needs.prepare-env.outputs.check_sha}}
 
       - name: Run Trivy vulnerability scanner in repo mode
-        uses: aquasecurity/trivy-action@0.16.0
+        uses: aquasecurity/trivy-action@0.16.1
         with:
           scan-type: "config"
           hide-progress: false
@@ -141,7 +141,7 @@ jobs:
           timeout: "10m0s"
 
       - name: Upload Trivy scan results to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@v3
         if: always()
         with:
           sarif_file: "trivy-results1.sarif"
@@ -176,7 +176,7 @@ jobs:
           tags: localhost:5000/traceability-foss:trivy
 
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@0.16.0
+        uses: aquasecurity/trivy-action@0.16.1
         with:
           image-ref: localhost:5000/traceability-foss:trivy
           trivyignores: "./.github/workflows/.trivyignore"
@@ -188,7 +188,7 @@ jobs:
 
       - name: Upload Trivy scan results to GitHub Security tab
         if: always()
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: "trivy-results2.sarif"
 

--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -22,3 +22,4 @@ The following people have contributed to this repository:
 - Lucas Capellino, doubleSlash Net-Business GmbH, https://github.com/ds-lcapellino
 - Abilash Shanmugavel, doubleSlash Net-Business GmbH, https://github.com/abi231002
 - Sebastian Ceronik, doubleSlash Net-Business GmbH, https://github.com/ds-ext-sceronik
+- Christian Rehm, doubleSlash Net-Business GmbH, https://github.com/ds-crehm

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,15 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Upgraded irs version from 6.12.0 to 6.13.0
 - Switched from OAuth2.0 to API Key authentication for IRS API Requests
 - switched from json-schema-friend:0.12.3 to json-schema-validator:5.4.0 for import file validation
+- Updated com.github.spotbugs:spotbugs-maven-plugin from 4.7.3.0 to 4.8.3.0
+- Updated actions/github-script from 5 to 7
+- Updated org.apache.maven.plugins:maven-surefire-plugin from 3.1.2 to 3.2.5
+- Updated org.apache.maven.plugins:maven-failsafe-plugin from 3.0.0-M8 to 3.2.5
+- Updated aquasecurity/trivy-action from 0.16.0 to 0.16.1
+- Updated actions/upload-artifact from 3 to 4
+- Updated github/codeql-action from 2 to 3
+- Updated actions/download-artifact from 3 to 4actions/download-artifact from 3 to 4
+- Updated com.nimbusds:nimbus-jose-jwt from 9.37.1 to 9.37.3
 
 ### Removed
 - Shell descriptor entity with underlying logic

--- a/DEPENDENCIES_BACKEND
+++ b/DEPENDENCIES_BACKEND
@@ -44,7 +44,7 @@ maven/mavencentral/com.googlecode.libphonenumber/libphonenumber/8.11.1, Apache-2
 maven/mavencentral/com.jayway.jsonpath/json-path/2.8.0, Apache-2.0, approved, clearlydefined
 maven/mavencentral/com.nimbusds/content-type/2.2, Apache-2.0, approved, clearlydefined
 maven/mavencentral/com.nimbusds/lang-tag/1.7, Apache-2.0, approved, clearlydefined
-maven/mavencentral/com.nimbusds/nimbus-jose-jwt/9.37.1, Apache-2.0, approved, #11701
+maven/mavencentral/com.nimbusds/nimbus-jose-jwt/9.37.3, Apache-2.0, approved, #11701
 maven/mavencentral/com.nimbusds/oauth2-oidc-sdk/9.43.3, Apache-2.0, approved, clearlydefined
 maven/mavencentral/com.squareup.okhttp3/okhttp-dnsoverhttps/4.10.0, Apache-2.0, approved, clearlydefined
 maven/mavencentral/com.squareup.okhttp3/okhttp-dnsoverhttps/4.11.0, Apache-2.0, approved, clearlydefined

--- a/pom.xml
+++ b/pom.xml
@@ -57,17 +57,17 @@ SPDX-License-Identifier: Apache-2.0
         <jacoco-plugin.version>0.8.8</jacoco-plugin.version>
         <jar-plugin.version>3.3.0</jar-plugin.version>
         <owasp-plugin.version>8.4.0</owasp-plugin.version>
-        <spotbugs-plugin.version>4.7.3.0</spotbugs-plugin.version>
+        <spotbugs-plugin.version>4.8.3.0</spotbugs-plugin.version>
         <spring-boot-maven-plugin.version>3.1.3</spring-boot-maven-plugin.version>
         <maven-project-info-reports-plugin.version>3.4.5</maven-project-info-reports-plugin.version>
         <sonar-maven-plugin.version>3.9.1.2184</sonar-maven-plugin.version>
-        <maven-surefire-plugin.version>3.1.2</maven-surefire-plugin.version>
-        <maven-failsafe-plugin.version>3.0.0-M8</maven-failsafe-plugin.version>
+        <maven-surefire-plugin.version>3.2.5</maven-surefire-plugin.version>
+        <maven-failsafe-plugin.version>3.2.5</maven-failsafe-plugin.version>
         <maven-site-plugin.version>4.0.0-M11</maven-site-plugin.version>
         <edc-library.version>0.1.3</edc-library.version>
         <!-- versions for 3rd party dependecies -->
         <eclipse-dash-ip.version>0.0.1-SNAPSHOT</eclipse-dash-ip.version>
-        <nimbus-jose-jwt.version>9.37.1</nimbus-jose-jwt.version>
+        <nimbus-jose-jwt.version>9.37.3</nimbus-jose-jwt.version>
         <ascii-doctor-j-diagram.version>2.2.13</ascii-doctor-j-diagram.version>
         <ascii-dcotor-j.version>2.5.8</ascii-dcotor-j.version>
         <auth-0-java-jwt.version>4.4.0</auth-0-java-jwt.version>

--- a/tx-backend/src/main/java/org/eclipse/tractusx/traceability/assets/application/importpoc/ImportService.java
+++ b/tx-backend/src/main/java/org/eclipse/tractusx/traceability/assets/application/importpoc/ImportService.java
@@ -16,6 +16,7 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
+// TODO package needs to be renamed (MW)
 package org.eclipse.tractusx.traceability.assets.application.importpoc;
 
 import org.eclipse.tractusx.traceability.assets.domain.base.model.AssetBase;

--- a/tx-backend/src/main/java/org/eclipse/tractusx/traceability/assets/domain/importpoc/service/MainAspectAsBuiltStrategy.java
+++ b/tx-backend/src/main/java/org/eclipse/tractusx/traceability/assets/domain/importpoc/service/MainAspectAsBuiltStrategy.java
@@ -48,6 +48,7 @@ import static org.eclipse.tractusx.traceability.assets.infrastructure.base.irs.m
 import static org.eclipse.tractusx.traceability.assets.infrastructure.base.irs.model.response.relationship.Aspect.isUpwardRelationshipAsBuilt;
 
 public class MainAspectAsBuiltStrategy implements MappingStrategy {
+    // TODO the mapping method here is almost the same as in SemanticDataModel.toDomainAsBuilt
     @Override
     public AssetBase mapToAssetBase(ImportRequest.AssetImportRequest assetImportRequestV2, TraceabilityProperties traceabilityProperties) {
 

--- a/tx-backend/src/main/java/org/eclipse/tractusx/traceability/assets/domain/importpoc/service/MainAspectAsPlannedStrategy.java
+++ b/tx-backend/src/main/java/org/eclipse/tractusx/traceability/assets/domain/importpoc/service/MainAspectAsPlannedStrategy.java
@@ -54,6 +54,7 @@ import static org.eclipse.tractusx.traceability.assets.infrastructure.base.irs.m
 
 public class MainAspectAsPlannedStrategy implements MappingStrategy {
 
+    // TODO the mapping method here is almost the same as in SemanticDataModel.toDomainAsPlanned
     @Override
     public AssetBase mapToAssetBase(ImportRequest.AssetImportRequest assetImportRequestV2, TraceabilityProperties traceabilityProperties) {
         List<GenericSubmodel> submodels = assetImportRequestV2.submodels();

--- a/tx-backend/src/main/java/org/eclipse/tractusx/traceability/assets/infrastructure/base/irs/JobRunning.java
+++ b/tx-backend/src/main/java/org/eclipse/tractusx/traceability/assets/infrastructure/base/irs/JobRunning.java
@@ -25,6 +25,7 @@ import org.eclipse.tractusx.traceability.assets.infrastructure.base.irs.model.re
 
 import java.util.function.Predicate;
 
+// TODO is this still needed - as we have changed from async runner for IRS Jobs to callback approach this should be deprecated. (MW)
 public class JobRunning implements Predicate<JobDetailResponse> {
     @Override
     public boolean test(JobDetailResponse jobResponse) {

--- a/tx-backend/src/main/java/org/eclipse/tractusx/traceability/assets/infrastructure/base/irs/model/response/JobDetailResponse.java
+++ b/tx-backend/src/main/java/org/eclipse/tractusx/traceability/assets/infrastructure/base/irs/model/response/JobDetailResponse.java
@@ -54,6 +54,7 @@ public record JobDetailResponse(
         Map<String, String> bpns
 ) {
 
+    // TODO constants should be in a proper class which reflects the purpose of it (MW)
     private static final String UNKNOWN_MANUFACTURER_NAME = "UNKNOWN_MANUFACTURER";
     private static final String SINGLE_LEVEL_USAGE_AS_BUILT = "SingleLevelUsageAsBuilt";
     private static final String SINGLE_LEVEL_BOM_AS_BUILT = "SingleLevelBomAsBuilt";
@@ -102,6 +103,8 @@ public record JobDetailResponse(
                 bpnsMap
         );
     }
+
+    // TODO is this still needed - as we have changed from async runner for IRS Jobs to callback approach this should be deprecated. (MW)
 
     public boolean isRunning() {
         return JOB_STATUS_RUNNING.equals(jobStatus.state());


### PR DESCRIPTION
## Description

### Changed
- Updated com.github.spotbugs:spotbugs-maven-plugin from 4.7.3.0 to 4.8.3.0
- Updated actions/github-script from 5 to 7
- Updated org.apache.maven.plugins:maven-surefire-plugin from 3.1.2 to 3.2.5
- Updated org.apache.maven.plugins:maven-failsafe-plugin from 3.0.0-M8 to 3.2.5
- Updated aquasecurity/trivy-action from 0.16.0 to 0.16.1
- Updated actions/upload-artifact from 3 to 4
- Updated github/codeql-action from 2 to 3
- Updated actions/download-artifact from 3 to 4actions/download-artifact from 3 to 4
- Updated com.nimbusds:nimbus-jose-jwt from 9.37.1 to 9.37.3