### PR TITLE
feat: reactivate natural sorting order of notification by severity

### DIFF
--- a/tx-backend/src/main/java/org/eclipse/tractusx/traceability/common/request/OwnPageable.java
+++ b/tx-backend/src/main/java/org/eclipse/tractusx/traceability/common/request/OwnPageable.java
@@ -74,7 +74,7 @@ public class OwnPageable {
             try {
                 String[] sortParams = sort.split(",");
                 orders.add(new Sort.Order(Sort.Direction.valueOf(sortParams[1].toUpperCase()),
-                        fieldMapper.mapRequestFieldName(sortParams[0])));
+                        handleEnumColumns(fieldMapper.mapRequestFieldName(sortParams[0]))));
             } catch (UnsupportedSearchCriteriaFieldException exception) {
                 throw exception;
             } catch (Exception exception) {
@@ -85,5 +85,12 @@ public class OwnPageable {
             }
         }
         return Sort.by(orders);
+    }
+
+    private static String handleEnumColumns(final String column) {
+        return switch (column) {
+            case "notifications_severity" -> "severityRank";
+            default -> column;
+        };
     }
 }

--- a/tx-backend/src/main/java/org/eclipse/tractusx/traceability/qualitynotification/infrastructure/alert/model/AlertEntity.java
+++ b/tx-backend/src/main/java/org/eclipse/tractusx/traceability/qualitynotification/infrastructure/alert/model/AlertEntity.java
@@ -41,6 +41,7 @@ import org.eclipse.tractusx.traceability.qualitynotification.domain.base.model.Q
 import org.eclipse.tractusx.traceability.qualitynotification.infrastructure.model.NotificationBaseEntity;
 import org.eclipse.tractusx.traceability.qualitynotification.infrastructure.model.NotificationSideBaseEntity;
 import org.eclipse.tractusx.traceability.qualitynotification.infrastructure.model.NotificationStatusBaseEntity;
+import org.hibernate.annotations.Formula;
 
 import java.util.List;
 
@@ -62,6 +63,13 @@ public class AlertEntity extends NotificationBaseEntity {
     )
     public List<AssetAsBuiltEntity> assets;
 
+    @Formula("(SELECT CASE " +
+            "WHEN A.severity = 'MINOR' THEN 0 " +
+            "WHEN A.severity = 'MAJOR' THEN 1 " +
+            "WHEN A.severity = 'CRITICAL' THEN 2 " +
+            "WHEN A.severity = 'LIFE_THREATENING' THEN 3 " +
+            "ELSE -1 END FROM alert_notification A WHERE A.alert_id = id LIMIT 1)")
+    private Integer severityRank;
 
     @OneToMany(mappedBy = "alert")
     private List<AlertNotificationEntity> notifications;

--- a/tx-backend/src/main/java/org/eclipse/tractusx/traceability/qualitynotification/infrastructure/investigation/model/InvestigationEntity.java
+++ b/tx-backend/src/main/java/org/eclipse/tractusx/traceability/qualitynotification/infrastructure/investigation/model/InvestigationEntity.java
@@ -43,6 +43,7 @@ import org.eclipse.tractusx.traceability.qualitynotification.domain.base.model.Q
 import org.eclipse.tractusx.traceability.qualitynotification.infrastructure.model.NotificationBaseEntity;
 import org.eclipse.tractusx.traceability.qualitynotification.infrastructure.model.NotificationSideBaseEntity;
 import org.eclipse.tractusx.traceability.qualitynotification.infrastructure.model.NotificationStatusBaseEntity;
+import org.hibernate.annotations.Formula;
 
 import java.util.List;
 
@@ -64,6 +65,13 @@ public class InvestigationEntity extends NotificationBaseEntity {
     )
     private List<AssetAsBuiltEntity> assets;
 
+    @Formula("(SELECT CASE " +
+            "WHEN A.severity = 'MINOR' THEN 0 " +
+            "WHEN A.severity = 'MAJOR' THEN 1 " +
+            "WHEN A.severity = 'CRITICAL' THEN 2 " +
+            "WHEN A.severity = 'LIFE_THREATENING' THEN 3 " +
+            "ELSE -1 END FROM alert_notification A WHERE A.alert_id = id LIMIT 1)")
+    private Integer severityRank;
 
     @OneToMany(mappedBy = "investigation")
     private List<InvestigationNotificationEntity> notifications;


### PR DESCRIPTION
This PR introduces a new feature: reactivate natural sorting order of notifications by severity

[Issue]:
- https://github.com/eclipse-tractusx/traceability-foss/issues/701 

[Summary]:
- This commit provides the sorting order of notifications (alerts and investigations) to follow a natural sorting order based on severity. Previously, the sorting method was sorted alphabetically

[Changes Made]:
- Modified/Added the SQL query responsible for sorting notifications by severity.

[Context/Reasoning]:
- Natural sorting by severity provides a more intuitive and user-friendly display of notifications, ensuring that higher severity issues are prioritized appropriately.