### PR TITLE
feature: 616 Allow edc notification update with empty asset list, release 10.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ _**For better traceability add the corresponding GitHub issue number in each cha
 - #706 Notification controller having the same endpoints as alerts and investigations controllers
 - #736 add contractAgreementId as searchable field for /contracts
 - Added capitalization section in guidelines.md
+- #616 Allow edc notification update with empty asset list
 
 ### Changed
 - #709 Bumped spring-core from 6.0.17 to 6.1.5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 _**For better traceability add the corresponding GitHub issue number in each changelog entry, please.**_
 
 ## [UNRELEASED - DD.MM.YYYY]
+
+## [10.8.0 - 03.04.2024]
+
 ### Added
 - #695 OAuth2.0 Client scope configuration
 - #606 Added error message into notifications on failure

--- a/COMPATIBILITY_MATRIX.md
+++ b/COMPATIBILITY_MATRIX.md
@@ -1,5 +1,34 @@
 # Compatibility matrix Trace-X
 
+## Trace-X version [[10.8.0](https://github.com/eclipse-tractusx/traceability-foss/releases/tag/10.8.0)] - 2024-04-03
+
+### Catena-X Release?
+
+- [ ] yes
+- [x] no
+
+### Helm Version [1.3.33](https://github.com/eclipse-tractusx/traceability-foss/releases/tag/helm-charts-1.3.33)
+
+| Dependency       | Name of Service              | Version                         | Helm   | Comments                                                                          |
+|------------------|------------------------------|---------------------------------|--------|-----------------------------------------------------------------------------------|
+| EDC              | edc-postgresql               | 12.1.6                          | 2.0.0  | Enterprise Data Connector for PostgreSQL                                          |
+| IRS              | irs-helm                     | 4.5.1                           | 6.14.1 | Helm charts for Item Relationship Service                                         |
+| EDC              | tractusx-connector           | 0.5.3                           | 2.0.0  | Connector for Data Transfer and Registration                                      |
+| Discovery Finder | discovery service            | v0.2.4-M1                       | 0.1.11 | Service for discovering and registering artifacts                                 |
+| Portal           | portal                       | 1.8.0                           | 1.8.0  | Web portal for interacting with Trace-X                                           |
+| SD-Factory       | SD-Factory                   | 2.1.7                           | 2.1.8  | Service Discovery Factory for managing dependencies                               |
+| Wallet           | wallet                       | 0.3.0                           | 0.3.0  | Secure storage for sensitive information                                          |
+| SDE              | Simple Data Exchanger (SDE)  | 2.3.3                           | 0.1.3  | Standalone service for companies to provide data in the Eclipse Tractus-X network |
+| Aspect Model     | SerialPart                   | [1.0.0,1.1.0,2.0.0,3.0.0)       | -      |                                                                                   |
+| Aspect Model     | Batch                        | [1.0.1,1.0.2,2.0.0,2.0.1,3.0.0) | -      |                                                                                   |
+| Aspect Model     | PartAsPlanned                | [1.0.0,1.0.1,2.0.0)             | -      |                                                                                   |
+| Aspect Model     | PartSiteInformationAsPlanned | [1.0.0]                         | -      |                                                                                   |
+| Aspect Model     | JustInSequencePart           | [1.0.0,2.0.0,3.0.0)             | -      |                                                                                   |
+| Aspect Model     | TractionBatteryCode          | [1.0.0]                         | -      |                                                                                   |
+| Aspect Model     | SingleLevelUsageAsBuilt      | [1.0.1]                         | -      |                                                                                   |
+| Aspect Model     | SingleLevelBomAsBuilt        | [1.0.0, 2.0.0)                  | -      |                                                                                   |
+| Aspect Model     | SingleLevelBomAsPlanned      | [1.0.1, 1.1.0)                  | -      |                                                                                   |
+
 ## Trace-X version [[10.7.0](https://github.com/eclipse-tractusx/traceability-foss/releases/tag/10.7.0)] - 2024-03-18
 
 ### Catena-X Release?

--- a/charts/traceability-foss/CHANGELOG.md
+++ b/charts/traceability-foss/CHANGELOG.md
@@ -4,7 +4,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.3.33] - 2024-04-03
+### No changes
+
 ## [1.3.32] - 2024-03-04
+
 ### No changes
 
 ## [1.3.31] - 2024-03-04

--- a/charts/traceability-foss/Chart.yaml
+++ b/charts/traceability-foss/Chart.yaml
@@ -23,15 +23,15 @@ home: https://eclipse-tractusx.github.io/
 sources:
   - https://github.com/eclipse-tractusx/traceability-foss
 type: application
-version: 1.3.32
-appVersion: "10.7.0"
+version: 1.3.33
+appVersion: "10.8.0"
 dependencies:
   - name: frontend
     repository: "file://charts/frontend"
-    version: 1.3.32
+    version: 1.3.33
   - name: backend
     repository: "file://charts/backend"
-    version: 1.3.32
+    version: 1.3.33
   - name: postgresql
     repository: https://charts.bitnami.com/bitnami
     version: 12.12.10

--- a/charts/traceability-foss/charts/backend/Chart.yaml
+++ b/charts/traceability-foss/charts/backend/Chart.yaml
@@ -20,8 +20,8 @@ apiVersion: v2
 name: backend
 description: A Helm chart for Traceability backend application.
 type: application
-version: 1.3.32
-appVersion: "10.7.0"
+version: 1.3.33
+appVersion: "10.8.0"
 dependencies:
   - name: postgresql
     repository: https://charts.bitnami.com/bitnami

--- a/charts/traceability-foss/charts/frontend/Chart.yaml
+++ b/charts/traceability-foss/charts/frontend/Chart.yaml
@@ -20,5 +20,5 @@ apiVersion: v2
 name: frontend
 description: A Helm chart for Traceability frontend application.
 type: application
-version: 1.3.32
-appVersion: "10.7.0"
+version: 1.3.33
+appVersion: "10.8.0"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trace-x",
-  "version": "10.7.0",
+  "version": "10.8.0",
   "scripts": {
     "analyze": "ng build --configuration=production --stats-json && webpack-bundle-analyzer dist/stats.json",
     "build:prod": "ng build --output-hashing=all --configuration=debugProd --base-href /{baseHrefPlaceholder}/ --deploy-url /{baseHrefPlaceholder}/ ",

--- a/pom.xml
+++ b/pom.xml
@@ -87,7 +87,7 @@ SPDX-License-Identifier: Apache-2.0
         <cucumber.version>7.15.0</cucumber.version>
         <junit-bom.version>5.10.2</junit-bom.version>
         <awaitility.version>3.0.0</awaitility.version>
-        <irs-client-lib.version>1.6.0</irs-client-lib.version>
+        <irs-client-lib.version>1.8.0</irs-client-lib.version>
         <json-schema-validator.version>5.4.0</json-schema-validator.version>
         <!-- Sonar related properties -->
         <sonar.java.coveragePlugin>jacoco</sonar.java.coveragePlugin>

--- a/tx-backend/src/main/java/org/eclipse/tractusx/traceability/common/model/SecurityUtils.java
+++ b/tx-backend/src/main/java/org/eclipse/tractusx/traceability/common/model/SecurityUtils.java
@@ -21,14 +21,17 @@ package org.eclipse.tractusx.traceability.common.model;
 
 
 import lombok.experimental.UtilityClass;
-import org.eclipse.tractusx.traceability.notification.infrastructure.edc.model.EDCNotification;
-import org.eclipse.tractusx.traceability.notification.infrastructure.edc.model.EDCNotificationContent;
-import org.eclipse.tractusx.traceability.notification.infrastructure.edc.model.EDCNotificationHeader;
 import notification.request.CloseNotificationRequest;
 import notification.request.StartNotificationRequest;
 import notification.request.UpdateNotificationRequest;
+import org.eclipse.tractusx.traceability.notification.infrastructure.edc.model.EDCNotification;
+import org.eclipse.tractusx.traceability.notification.infrastructure.edc.model.EDCNotificationContent;
+import org.eclipse.tractusx.traceability.notification.infrastructure.edc.model.EDCNotificationHeader;
 
+import java.util.Collections;
 import java.util.List;
+
+import static org.apache.commons.collections4.ListUtils.emptyIfNull;
 
 @UtilityClass
 public class SecurityUtils {
@@ -49,7 +52,7 @@ public class SecurityUtils {
                     .map(SecurityUtils::sanitize)
                     .toList();
         }
-        return null;
+        return Collections.emptyList();
     }
 
     public static StartNotificationRequest sanitize(StartNotificationRequest request) {
@@ -104,7 +107,7 @@ public class SecurityUtils {
 
     private static EDCNotificationContent sanitize(EDCNotificationContent edcNotificationContent) {
         String cleanInformation = sanitize(edcNotificationContent.information());
-        List<String> cleanStringListOfAffectedItems = sanitize(edcNotificationContent.listOfAffectedItems());
+        List<String> cleanStringListOfAffectedItems = sanitize(emptyIfNull(edcNotificationContent.listOfAffectedItems()));
         return new EDCNotificationContent(cleanInformation, cleanStringListOfAffectedItems);
     }
 }

--- a/tx-backend/src/main/java/org/eclipse/tractusx/traceability/notification/infrastructure/edc/model/EDCNotification.java
+++ b/tx-backend/src/main/java/org/eclipse/tractusx/traceability/notification/infrastructure/edc/model/EDCNotification.java
@@ -32,6 +32,8 @@ import org.eclipse.tractusx.traceability.notification.domain.base.model.Notifica
 import java.time.Instant;
 import java.util.List;
 
+import static org.apache.commons.collections4.ListUtils.emptyIfNull;
+
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public record EDCNotification(@Valid
                               @NotNull
@@ -81,7 +83,7 @@ public record EDCNotification(@Valid
 
     @JsonIgnore
     public List<NotificationAffectedPart> getListOfAffectedItems() {
-        return content.listOfAffectedItems().stream()
+        return emptyIfNull(content.listOfAffectedItems()).stream()
                 .map(NotificationAffectedPart::new).toList();
     }
 


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
## Added
- #616 Allow edc notification update with empty asset list
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
