### PR TITLE
feature: #859 enable autocomplete API to filter for given assets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ _**For better traceability add the corresponding GitHub issue number in each cha
 - #844 Validation for BPN to Notification API (Create / Edit), Fixed pagination
 - #726 Added @Preauthorize annotation to dashboard controller
 - #837 Added digital twin type to data provisioning workflow to be able to lookup shells created by trace-x
+- #859 Enable autocomplete API to filter for given assets
 
 ### Changed
 - #844 Prefilled bpn on investigation creation

--- a/tx-backend/src/main/java/org/eclipse/tractusx/traceability/assets/application/asbuilt/rest/AssetAsBuiltController.java
+++ b/tx-backend/src/main/java/org/eclipse/tractusx/traceability/assets/application/asbuilt/rest/AssetAsBuiltController.java
@@ -33,7 +33,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
-import jakarta.ws.rs.QueryParam;
+import org.apache.commons.lang3.ArrayUtils;
 import org.eclipse.tractusx.traceability.assets.application.asbuilt.mapper.AssetAsBuiltFieldMapper;
 import org.eclipse.tractusx.traceability.assets.application.asbuilt.mapper.AssetAsBuiltResponseMapper;
 import org.eclipse.tractusx.traceability.assets.application.asbuilt.mapper.QualityTypeMapper;
@@ -53,8 +53,10 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
@@ -254,8 +256,17 @@ public class AssetAsBuiltController {
                             mediaType = "application/json",
                             schema = @Schema(implementation = ErrorResponse.class)))})
     @GetMapping("distinctFilterValues")
-    public List<String> distinctFilterValues(@QueryParam("fieldName") String fieldName, @QueryParam("size") Integer size, @QueryParam("startWith") String startWith, @QueryParam("owner") Owner owner) {
-        return assetBaseService.getDistinctFilterValues(fieldMapper.mapRequestFieldName(fieldName), startWith, size, owner);
+    public List<String> distinctFilterValues(
+            @RequestParam("fieldName") String fieldName,
+            @RequestParam(value = "size", required = false) Integer size,
+            @RequestParam(value = "startWith", required = false) String startWith,
+            @RequestParam(value = "owner", required = false) Owner owner,
+            @RequestParam(value = "inAssetIds", required = false) String[] inAssetIds) {
+        List<String> inAssetIdsList = List.of();
+        if (ArrayUtils.isNotEmpty(inAssetIds)) {
+            inAssetIdsList = Arrays.asList(inAssetIds);
+        }
+        return assetBaseService.getDistinctFilterValues(fieldMapper.mapRequestFieldName(fieldName), startWith, size, owner, inAssetIdsList);
     }
 
     @Operation(operationId = "assetsCountryMap",

--- a/tx-backend/src/main/java/org/eclipse/tractusx/traceability/assets/application/asplanned/rest/AssetAsPlannedController.java
+++ b/tx-backend/src/main/java/org/eclipse/tractusx/traceability/assets/application/asplanned/rest/AssetAsPlannedController.java
@@ -31,6 +31,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import org.apache.commons.lang3.ArrayUtils;
 import org.eclipse.tractusx.traceability.assets.application.asbuilt.mapper.QualityTypeMapper;
 import org.eclipse.tractusx.traceability.assets.application.asplanned.mapper.AssetAsPlannedFieldMapper;
 import org.eclipse.tractusx.traceability.assets.application.asplanned.mapper.AssetAsPlannedResponseMapper;
@@ -53,6 +54,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.util.Arrays;
 import java.util.List;
 
 @RestController
@@ -250,8 +252,17 @@ public class AssetAsPlannedController {
                             mediaType = "application/json",
                             schema = @Schema(implementation = ErrorResponse.class)))})
     @GetMapping("distinctFilterValues")
-    public List<String> distinctFilterValues(@RequestParam("fieldName") String fieldName, @RequestParam(value = "size", required = false) Integer size, @RequestParam(value = "startWith", required = false) String startWith, @RequestParam(value = "owner", required = false) Owner owner) {
-        return assetService.getDistinctFilterValues(fieldMapper.mapRequestFieldName(fieldName), startWith, size, owner);
+    public List<String> distinctFilterValues(
+            @RequestParam("fieldName") String fieldName,
+            @RequestParam(value = "size", required = false) Integer size,
+            @RequestParam(value = "startWith", required = false) String startWith,
+            @RequestParam(value = "owner", required = false) Owner owner,
+            @RequestParam(value = "inAssetIds", required = false) String[] inAssetIds) {
+        List<String> inAssetIdsList = List.of();
+        if (ArrayUtils.isNotEmpty(inAssetIds)) {
+            inAssetIdsList = Arrays.asList(inAssetIds);
+        }
+        return assetService.getDistinctFilterValues(fieldMapper.mapRequestFieldName(fieldName), startWith, size, owner, inAssetIdsList);
     }
 
     @Operation(operationId = "assetById",

--- a/tx-backend/src/main/java/org/eclipse/tractusx/traceability/assets/application/base/service/AssetBaseService.java
+++ b/tx-backend/src/main/java/org/eclipse/tractusx/traceability/assets/application/base/service/AssetBaseService.java
@@ -47,7 +47,7 @@ public interface AssetBaseService {
 
     AssetBase updateQualityType(String assetId, QualityType qualityType);
 
-    List<String> getDistinctFilterValues(String fieldName, String startWith, Integer size, Owner owner);
+    List<String> getDistinctFilterValues(String fieldName, String startWith, Integer size, Owner owner, List<String> inAssetIds);
 
     List<String> getAssetIdsInImportState(ImportState... importStates);
 }

--- a/tx-backend/src/main/java/org/eclipse/tractusx/traceability/assets/domain/base/AssetRepository.java
+++ b/tx-backend/src/main/java/org/eclipse/tractusx/traceability/assets/domain/base/AssetRepository.java
@@ -46,7 +46,7 @@ public interface AssetRepository {
 
     long countAssetsByOwner(Owner owner);
 
-    List<String> getFieldValues(String fieldName, String startWith, Integer resultLimit, Owner owner);
+    List<String> getFieldValues(String fieldName, String startWith, Integer resultLimit, Owner owner, List<String> inAssetIds);
 
     List<AssetBase> findByImportStateIn(ImportState... importStates);
 

--- a/tx-backend/src/main/java/org/eclipse/tractusx/traceability/assets/domain/base/service/AbstractAssetBaseService.java
+++ b/tx-backend/src/main/java/org/eclipse/tractusx/traceability/assets/domain/base/service/AbstractAssetBaseService.java
@@ -117,13 +117,13 @@ public abstract class AbstractAssetBaseService implements AssetBaseService {
     }
 
     @Override
-    public List<String> getDistinctFilterValues(String fieldName, String startWith, Integer size, Owner owner) {
+    public List<String> getDistinctFilterValues(String fieldName, String startWith, Integer size, Owner owner, List<String> inAssetIds) {
         final Integer resultSize = Objects.isNull(size) ? Integer.MAX_VALUE : size;
 
         if (isSupportedEnumType(fieldName)) {
             return getAssetEnumFieldValues(fieldName);
         }
-        return getAssetRepository().getFieldValues(fieldName, startWith, resultSize, owner);
+        return getAssetRepository().getFieldValues(fieldName, startWith, resultSize, owner, inAssetIds);
     }
 
     @Override

--- a/tx-backend/src/main/java/org/eclipse/tractusx/traceability/assets/infrastructure/asbuilt/repository/AssetAsBuiltRepositoryImpl.java
+++ b/tx-backend/src/main/java/org/eclipse/tractusx/traceability/assets/infrastructure/asbuilt/repository/AssetAsBuiltRepositoryImpl.java
@@ -80,8 +80,8 @@ public class AssetAsBuiltRepositoryImpl implements AssetAsBuiltRepository, Asset
     }
 
     @Override
-    public List<String> getFieldValues(String fieldName, String startWith, Integer resultLimit, Owner owner) {
-        return CriteriaUtility.getDistinctAssetFieldValues(fieldName, startWith, resultLimit, owner, AssetAsBuiltEntity.class, entityManager);
+    public List<String> getFieldValues(String fieldName, String startWith, Integer resultLimit, Owner owner, List<String> inAssetIds) {
+        return CriteriaUtility.getDistinctAssetFieldValues(fieldName, startWith, resultLimit, owner, inAssetIds, AssetAsBuiltEntity.class, entityManager);
     }
 
     @Override

--- a/tx-backend/src/main/java/org/eclipse/tractusx/traceability/assets/infrastructure/asplanned/repository/AssetAsPlannedRepositoryImpl.java
+++ b/tx-backend/src/main/java/org/eclipse/tractusx/traceability/assets/infrastructure/asplanned/repository/AssetAsPlannedRepositoryImpl.java
@@ -154,8 +154,8 @@ public class AssetAsPlannedRepositoryImpl implements AssetAsPlannedRepository, A
     }
 
     @Override
-    public List<String> getFieldValues(String fieldName, String startWith, Integer resultLimit, Owner owner) {
-        return CriteriaUtility.getDistinctAssetFieldValues(fieldName, startWith, resultLimit, owner, AssetAsPlannedEntity.class, entityManager);
+    public List<String> getFieldValues(String fieldName, String startWith, Integer resultLimit, Owner owner, List<String> inAssetIds) {
+        return CriteriaUtility.getDistinctAssetFieldValues(fieldName, startWith, resultLimit, owner, inAssetIds, AssetAsPlannedEntity.class, entityManager);
     }
 
     @Transactional

--- a/tx-backend/src/main/java/org/eclipse/tractusx/traceability/common/repository/CriteriaUtility.java
+++ b/tx-backend/src/main/java/org/eclipse/tractusx/traceability/common/repository/CriteriaUtility.java
@@ -28,6 +28,7 @@ import jakarta.persistence.criteria.Path;
 import jakarta.persistence.criteria.Predicate;
 import jakarta.persistence.criteria.Root;
 import lombok.experimental.UtilityClass;
+import org.apache.commons.collections.CollectionUtils;
 import org.eclipse.tractusx.traceability.assets.domain.base.model.Owner;
 import org.eclipse.tractusx.traceability.notification.domain.base.model.NotificationSide;
 
@@ -44,6 +45,7 @@ public class CriteriaUtility {
             String startWith,
             Integer resultLimit,
             Owner owner,
+            List<String> inAssetIds,
             Class<?> assetEntityClass,
             EntityManager entityManager) {
         CriteriaBuilder builder = entityManager.getCriteriaBuilder();
@@ -68,6 +70,11 @@ public class CriteriaUtility {
         if (nonNull(owner)) {
             predicates.add(builder.equal(root.get("owner").as(String.class), owner.name()));
         }
+
+        if (!CollectionUtils.isEmpty(inAssetIds)) {
+            predicates.add(root.get("id").as(String.class).in(inAssetIds));
+        }
+
         cq.where(predicates.toArray(new Predicate[0]));
         return entityManager.createQuery(cq)
                 .setMaxResults(resultLimit)

--- a/tx-backend/src/test/java/org/eclipse/tractusx/traceability/assets/domain/base/service/AbstractAssetBaseServiceTest.java
+++ b/tx-backend/src/test/java/org/eclipse/tractusx/traceability/assets/domain/base/service/AbstractAssetBaseServiceTest.java
@@ -32,7 +32,7 @@ class AbstractAssetBaseServiceTest {
         // given params
 
         // when
-        List<String> result = service.getDistinctFilterValues(fieldName, startWith, 10, null);
+        List<String> result = service.getDistinctFilterValues(fieldName, startWith, 10, null, List.of());
 
         // then
         assertThat(result).containsAll(expectedValues);

--- a/tx-backend/src/test/java/org/eclipse/tractusx/traceability/integration/assets/AssetAsBuiltControllerFilterValuesIT.java
+++ b/tx-backend/src/test/java/org/eclipse/tractusx/traceability/integration/assets/AssetAsBuiltControllerFilterValuesIT.java
@@ -278,6 +278,33 @@ class AssetAsBuiltControllerFilterValuesIT extends IntegrationTestSpecification 
                 .body("size()", is(6));
     }
 
+    @Test
+    void givenInAssetListIsProvided_whenCallDistinctFilterValues_thenProperResponse() throws JoseException {
+        // given
+        assetsSupport.defaultAssetsStored();
+        String fieldName = "id";
+        String resultLimit = "100";
+        String owner = "SUPPLIER";
+        String inAssetIds = "urn:uuid:0ce83951-bc18-4e8f-892d-48bad4eb67ef,urn:uuid:16bb1a7e-8ed8-48ca-a839-5f38b704fcae";
+
+        // then
+        given()
+                .header(oAuth2Support.jwtAuthorization(ADMIN))
+                .contentType(ContentType.JSON)
+                .log().all()
+                .when()
+                .param("fieldName", fieldName)
+                .param("size", resultLimit)
+                .param("owner", owner)
+                .param("inAssetIds", inAssetIds)
+                .get("/api/assets/as-built/distinctFilterValues")
+                .then()
+                .log().all()
+                .statusCode(200)
+                .assertThat()
+                .body("size()", is(2));
+    }
+
     private static Stream<Arguments> fieldNameTestProvider() {
         return Stream.of(
                 Arguments.of("id", 10L, 10),

--- a/tx-backend/src/test/java/org/eclipse/tractusx/traceability/integration/assets/AssetAsPlannedControllerFilterValuesIT.java
+++ b/tx-backend/src/test/java/org/eclipse/tractusx/traceability/integration/assets/AssetAsPlannedControllerFilterValuesIT.java
@@ -244,6 +244,33 @@ class AssetAsPlannedControllerFilterValuesIT extends IntegrationTestSpecificatio
                 .body("size()", is(6));
     }
 
+    @Test
+    void givenInAssetListIsProvided_whenCallDistinctFilterValues_thenProperResponse() throws JoseException {
+        // given
+        assetsSupport.defaultAssetsAsPlannedStored();
+        String fieldName = "id";
+        String resultLimit = "100";
+        String owner = "OWN";
+        String inAssetIds = "urn:uuid:0733946c-59c6-41ae-9570-cb43a6e4da01";
+
+        // then
+        given()
+                .header(oAuth2Support.jwtAuthorization(ADMIN))
+                .contentType(ContentType.JSON)
+                .log().all()
+                .when()
+                .param("fieldName", fieldName)
+                .param("size", resultLimit)
+                .param("owner", owner)
+                .param("inAssetIds", inAssetIds)
+                .get("/api/assets/as-planned/distinctFilterValues")
+                .then()
+                .log().all()
+                .statusCode(200)
+                .assertThat()
+                .body("size()", is(1));
+    }
+
     private static Stream<Arguments> fieldNameTestProvider() {
         return Stream.of(
                 Arguments.of("id", 10L, 2),

--- a/tx-backend/src/test/java/org/eclipse/tractusx/traceability/integration/assets/asbuilt/infrastructure/repository/AssetAsBuiltRepositoryIT.java
+++ b/tx-backend/src/test/java/org/eclipse/tractusx/traceability/integration/assets/asbuilt/infrastructure/repository/AssetAsBuiltRepositoryIT.java
@@ -26,7 +26,6 @@ import org.eclipse.tractusx.traceability.assets.infrastructure.asbuilt.model.Ass
 import org.eclipse.tractusx.traceability.assets.infrastructure.asbuilt.repository.JpaAssetAsBuiltRepository;
 import org.eclipse.tractusx.traceability.integration.IntegrationTestSpecification;
 import org.eclipse.tractusx.traceability.integration.common.support.AssetsSupport;
-import org.eclipse.tractusx.traceability.integration.common.support.BpnSupport;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -61,7 +60,7 @@ class AssetAsBuiltRepositoryIT extends IntegrationTestSpecification {
         assetsSupport.defaultAssetsStored();
 
         // when
-        List<String> result = assetAsBuiltRepository.getFieldValues(fieldName, startWith, resultLimit, null);
+        List<String> result = assetAsBuiltRepository.getFieldValues(fieldName, startWith, resultLimit, null, List.of());
 
         // then
         assertThat(result)

--- a/tx-backend/src/test/java/org/eclipse/tractusx/traceability/integration/assets/asplanned/infrastructure/repository/AssetAsPlannedRepositoryIT.java
+++ b/tx-backend/src/test/java/org/eclipse/tractusx/traceability/integration/assets/asplanned/infrastructure/repository/AssetAsPlannedRepositoryIT.java
@@ -52,7 +52,7 @@ class AssetAsPlannedRepositoryIT extends IntegrationTestSpecification {
         assetsSupport.defaultAssetsAsPlannedStored();
 
         // when
-        List<String> result = assetAsPlannedRepository.getFieldValues(fieldName, startWith, resultLimit, null);
+        List<String> result = assetAsPlannedRepository.getFieldValues(fieldName, startWith, resultLimit, null, List.of());
 
         // then
         assertThat(result)


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

resolves #859 

## Description
This PR introduces functionality to the autocomplete API to handle a given list of assets. With this, the API only searches in a given set of assets in the database to minimize workload. 
The new query parameter `inAssetIds` accepts multiple asset IDs with comma separation. For e.g. :

`/api/assets/as-planned/distinctFilterValues?fieldName=nameAtManufacturer&size=100&inAssetIds=urn%3Auuid%3A0733946c-59c6-41ae-9570-cb43a6e4da01%2Curn%3Auuid%3A0733946c-59c6-41ae-9570-cb43a6e4eb01`

returns only two distinct autocomplete values for the given asset IDs 
- urn:uuid:0733946c-59c6-41ae-9570-cb43a6e4da01
- urn:uuid:0733946c-59c6-41ae-9570-cb43a6e4eb01


### Added
- #859 Enable autocomplete API to filter for given assets

<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
