### PR TITLE
feature : sorting by status according to the natural order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 _**For better traceability add the corresponding GitHub issue number in each changelog entry, please.**_
 ## [UNRELEASED - DD.MM.YYYY]
+
+
+## [UNRELEASED - 07.05.2024]
+
+### Added
+- #779 Created new enum type for status
+- #779 Added asset_as_build view to after updating status column type
+- #779 Added new dependency hypersistence-utils-hibernate-63 to map enum to string
+
+### changed
+- #779 feat: reactivate natural sorting order of notification by status
+- #779 updated status column type of notification and notification_message
+
+### Removed
+- #779 Dropped asset_as_build view to update status column type varchar to enum but added again
+
+## [UNRELEASED - DD.MM.YYYY]
 ### Added
 - #844 Validation for BPN to Notification API (Create / Edit), Fixed pagination
 - #726 Added @Preauthorize annotation to dashboard controller

--- a/pom.xml
+++ b/pom.xml
@@ -62,6 +62,7 @@ SPDX-License-Identifier: Apache-2.0
         <maven-site-plugin.version>4.0.0-M11</maven-site-plugin.version>
         <edc-library.version>0.2.1</edc-library.version>
         <!-- versions for 3rd party dependecies -->
+        <hypersistence-utils-hibernate.version>3.7.5</hypersistence-utils-hibernate.version>
         <logback.version>1.5.5</logback.version>
         <eclipse-dash-ip.version>1.1.0</eclipse-dash-ip.version>
         <nimbus-jose-jwt.version>9.37.3</nimbus-jose-jwt.version>

--- a/tx-backend/pom.xml
+++ b/tx-backend/pom.xml
@@ -58,7 +58,11 @@ SPDX-License-Identifier: Apache-2.0
             <artifactId>json-schema-validator</artifactId>
             <version>${json-schema-validator.version}</version>
         </dependency>
-
+        <dependency>
+            <groupId>io.hypersistence</groupId>
+            <artifactId>hypersistence-utils-hibernate-63</artifactId>
+            <version>${hypersistence-utils-hibernate.version}</version>
+        </dependency>
         <!-- IRS Client for decentral registry approach -->
         <dependency>
             <groupId>org.eclipse.tractusx.irs</groupId>

--- a/tx-backend/src/main/java/org/eclipse/tractusx/traceability/notification/infrastructure/notification/model/NotificationBaseEntity.java
+++ b/tx-backend/src/main/java/org/eclipse/tractusx/traceability/notification/infrastructure/notification/model/NotificationBaseEntity.java
@@ -28,6 +28,8 @@ import jakarta.persistence.MappedSuperclass;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
 
 import java.time.Instant;
 
@@ -51,6 +53,8 @@ public class NotificationBaseEntity {
     @Enumerated(EnumType.STRING)
     private NotificationSideBaseEntity side;
     @Enumerated(EnumType.STRING)
+    @Column(columnDefinition = "status")
+    @JdbcTypeCode(SqlTypes.NAMED_ENUM)
     private NotificationStatusBaseEntity status;
 
 }

--- a/tx-backend/src/main/java/org/eclipse/tractusx/traceability/notification/infrastructure/notification/model/NotificationMessageBaseEntity.java
+++ b/tx-backend/src/main/java/org/eclipse/tractusx/traceability/notification/infrastructure/notification/model/NotificationMessageBaseEntity.java
@@ -18,15 +18,13 @@
  ********************************************************************************/
 package org.eclipse.tractusx.traceability.notification.infrastructure.notification.model;
 
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
-import jakarta.persistence.Id;
-import jakarta.persistence.MappedSuperclass;
-import jakarta.persistence.PreUpdate;
+import jakarta.persistence.*;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
 import org.eclipse.tractusx.traceability.notification.domain.base.model.NotificationSeverity;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
 
 import java.time.Instant;
 import java.time.LocalDateTime;
@@ -52,6 +50,8 @@ public class NotificationMessageBaseEntity {
     private LocalDateTime updated;
     private String messageId;
     @Enumerated(EnumType.STRING)
+    @Column(columnDefinition = "status")
+    @JdbcTypeCode(SqlTypes.NAMED_ENUM)
     private NotificationStatusBaseEntity status;
     private String errorMessage;
 

--- a/tx-backend/src/main/resources/db/migration/V23__create_status_enum_type.sql
+++ b/tx-backend/src/main/resources/db/migration/V23__create_status_enum_type.sql
@@ -1,0 +1,77 @@
+DROP VIEW IF EXISTS assets_as_built_view;
+
+CREATE TYPE status AS ENUM ('CREATED', 'SENT', 'RECEIVED', 'ACKNOWLEDGED', 'CANCELED', 'ACCEPTED', 'DECLINED', 'CLOSED');
+
+ALTER TABLE notification ALTER COLUMN "status" TYPE status USING ("status"::status);
+ALTER TABLE notification_message ALTER COLUMN "status" TYPE status USING ("status"::status);
+
+CREATE CAST (varchar AS status) WITH INOUT AS IMPLICIT;
+
+create
+or replace view assets_as_built_view as
+select asset.*,
+       (select count(notification.id)
+        from notification notification
+                 join
+             assets_as_built_notifications notification_assets
+             on notification.id = notification_assets.notification_id
+        where (
+            cast(notification.status as text) = 'CREATED'
+                or cast(notification.status as text) = 'SENT'
+                or cast(notification.status as text) = 'RECEIVED'
+                or cast(notification.status as text) = 'ACKNOWLEDGED'
+                or cast(notification.status as text) = 'ACCEPTED'
+                or cast(notification.status as text) = 'DECLINED'
+            )
+          and cast(notification.side as text) = 'RECEIVER'
+          and cast(notification.type as text) = 'ALERT'
+          and notification_assets.asset_id = asset.id)         as received_active_alerts,
+       (select count(notification.id)
+        from notification notification
+                 join
+             assets_as_built_notifications notification_assets
+             on notification.id = notification_assets.notification_id
+        where (
+            cast(notification.status as text) = 'CREATED'
+                or cast(notification.status as text) = 'SENT'
+                or cast(notification.status as text) = 'RECEIVED'
+                or cast(notification.status as text) = 'ACKNOWLEDGED'
+                or cast(notification.status as text) = 'ACCEPTED'
+                or cast(notification.status as text) = 'DECLINED'
+            )
+          and cast(notification.side as text) = 'SENDER'
+          and cast(notification.type as text) = 'ALERT'
+          and notification_assets.asset_id = asset.id)         as sent_active_alerts,
+       (select count(notification.id)
+        from notification notification
+                 join
+             assets_as_built_notifications notification_assets
+             on notification.id = notification_assets.notification_id
+        where (
+            cast(notification.status as text) = 'CREATED'
+                or cast(notification.status as text) = 'SENT'
+                or cast(notification.status as text) = 'RECEIVED'
+                or cast(notification.status as text) = 'ACKNOWLEDGED'
+                or cast(notification.status as text) = 'ACCEPTED'
+                or cast(notification.status as text) = 'DECLINED'
+            )
+          and cast(notification.side as text) = 'RECEIVER'
+          and cast(notification.type as text) = 'INVESTIGATION'
+          and notification_assets.asset_id = asset.id) as received_active_investigations,
+       (select count(notification.id)
+        from notification notification
+                 join
+             assets_as_built_notifications notification_assets
+             on notification.id = notification_assets.notification_id
+        where (
+            cast(notification.status as text) = 'CREATED'
+                or cast(notification.status as text) = 'SENT'
+                or cast(notification.status as text) = 'RECEIVED'
+                or cast(notification.status as text) = 'ACKNOWLEDGED'
+                or cast(notification.status as text) = 'ACCEPTED'
+                or cast(notification.status as text) = 'DECLINED'
+            )
+          and cast(notification.side as text) = 'SENDER'
+          and cast(notification.type as text) = 'INVESTIGATION'
+          and notification_assets.asset_id = asset.id) as sent_active_investigations
+from assets_as_built as asset;

--- a/tx-backend/src/test/java/org/eclipse/tractusx/traceability/integration/notification/alert/ReadAlertsControllerIT.java
+++ b/tx-backend/src/test/java/org/eclipse/tractusx/traceability/integration/notification/alert/ReadAlertsControllerIT.java
@@ -184,7 +184,7 @@ class ReadAlertsControllerIT extends IntegrationTestSpecification {
                 .body("pageSize", Matchers.is(10))
                 .body("totalItems", Matchers.is(8))
                 .body("content", Matchers.hasSize(8))
-                .body("content.status", Matchers.containsInRelativeOrder("ACCEPTED", "ACKNOWLEDGED", "CANCELED", "CLOSED", "CREATED", "DECLINED", "RECEIVED", "SENT"));
+                .body("content.status", Matchers.containsInRelativeOrder("CREATED", "SENT", "RECEIVED", "ACKNOWLEDGED", "CANCELED", "ACCEPTED", "DECLINED", "CLOSED"));
     }
 
     @Test

--- a/tx-backend/src/test/java/org/eclipse/tractusx/traceability/integration/notification/investigation/ReadInvestigationsControllerIT.java
+++ b/tx-backend/src/test/java/org/eclipse/tractusx/traceability/integration/notification/investigation/ReadInvestigationsControllerIT.java
@@ -184,7 +184,7 @@ class ReadInvestigationsControllerIT extends IntegrationTestSpecification {
                 .body("pageSize", Matchers.is(10))
                 .body("totalItems", Matchers.is(8))
                 .body("content", Matchers.hasSize(8))
-                .body("content.status", Matchers.containsInRelativeOrder("ACCEPTED", "ACKNOWLEDGED", "CANCELED", "CLOSED", "CREATED", "DECLINED", "RECEIVED", "SENT"));
+                .body("content.status", Matchers.containsInRelativeOrder("CREATED", "SENT", "RECEIVED", "ACKNOWLEDGED", "CANCELED", "ACCEPTED", "DECLINED", "CLOSED"));
     }
 
     @Test


### PR DESCRIPTION
feat: reactivate natural sorting order of notification by status #779


This PR introduces a new feature: reactivate natural sorting order of notifications by status

[Issue]:
* The notifications are sorted by status according to the natural order of the attribute (https://github.com/eclipse-tractusx/traceability-foss/issues/702)

[Summary]:
* This commit provides the sorting order of notifications (alerts and investigations) to follow a natural sorting order based on status. Previously, the sorting method was sorted alphabetically

[Changes Made]:
* Modified/Added the SQL query responsible for sorting notifications by status.

[Context/Reasoning]:
* Natural sorting by status provides a more intuitive and user-friendly display of notifications.