### PR TITLE
bug: #778 return empty page result insteadof http 404

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 _**For better traceability add the corresponding GitHub issue number in each changelog entry, please.**_
 ## [UNRELEASED - DD.MM.YYYY]
 
+### Changed
+- #778 return empty PageResult when no contract agreement Ids are found instead of http 404 in /contacts API
+
 ## [11.0.0 - 08.05.2024]
 ### Added
 - #844 Validation for BPN to Notification API (Create / Edit), Fixed pagination

--- a/tx-backend/src/main/java/org/eclipse/tractusx/traceability/contracts/infrastructure/repository/ContractRepositoryImpl.java
+++ b/tx-backend/src/main/java/org/eclipse/tractusx/traceability/contracts/infrastructure/repository/ContractRepositoryImpl.java
@@ -70,7 +70,8 @@ public class ContractRepositoryImpl implements ContractRepository {
             Page<ContractAgreementView> contractAgreementInfoViews = contractAgreementInfoViewRepository.findAll(specification, pageable);
 
             if (contractAgreementInfoViews.getContent().isEmpty()) {
-                throw new ContractException("Cannot find contract agreement Ids for asset ids in searchCriteria: " + searchCriteria.getSearchCriteriaFilterList());
+                log.warn("Cannot find contract agreement Ids for asset ids in searchCriteria: " + searchCriteria.getSearchCriteriaFilterList());
+                return new PageResult<>(List.of(), 0, 0, 0, 0L);
             }
 
             return new PageResult<>(fetchEdcContractAgreements(contractAgreementInfoViews),

--- a/tx-backend/src/test/java/org/eclipse/tractusx/traceability/integration/contracts/ContractControllerIT.java
+++ b/tx-backend/src/test/java/org/eclipse/tractusx/traceability/integration/contracts/ContractControllerIT.java
@@ -142,14 +142,14 @@ class ContractControllerIT extends IntegrationTestSpecification {
     }
 
     @Test
-    void shouldReturn404IfAssetIdIsUnknown() throws JoseException {
+    void shouldReturnEmptyIfAssetIdIsUnknown() throws JoseException {
         //GIVEN
         edcSupport.edcWillReturnOnlyOneContractAgreement();
         edcSupport.edcWillReturnContractAgreementNegotiation();
         assetsSupport.defaultAssetsStored();
 
         //WHEN//THEN
-        given()
+        PageResult<ContractResponse> contractResponsePageResult = given()
                 .header(oAuth2Support.jwtAuthorization(ADMIN))
                 .contentType(ContentType.JSON)
                 .log().all()
@@ -158,7 +158,11 @@ class ContractControllerIT extends IntegrationTestSpecification {
                 .post("/api/contracts")
                 .then()
                 .log().all()
-                .statusCode(404);
+                .statusCode(200)
+                .extract().body().as(new TypeRef<>() {
+                });
+        //THEN
+        assertThat(contractResponsePageResult.content()).isEmpty();
     }
 
 }


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->
This PR fixes a bug in the /contracts API where an HTTP404 is returned in case of no present contract agreement IDs. Since this API returns a PageResult, the response should be HTTP 200 with an empty PageResult. This bug was discovered with the migration to EDC 0.7.0 (#778)
Warning logs are also added with this PR.

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
