### PR TITLE
bug: #639 update policies provider after crud operations on policies

### DIFF
--- a/tx-backend/src/test/java/org/eclipse/tractusx/traceability/assets/infrastructure/base/irs/PolicyRepositoryImplTest.java
+++ b/tx-backend/src/test/java/org/eclipse/tractusx/traceability/assets/infrastructure/base/irs/PolicyRepositoryImplTest.java
@@ -19,6 +19,7 @@
 
 package org.eclipse.tractusx.traceability.assets.infrastructure.base.irs;
 
+import org.eclipse.tractusx.irs.edc.client.policy.AcceptedPoliciesProvider;
 import org.eclipse.tractusx.irs.edc.client.policy.Constraint;
 import org.eclipse.tractusx.irs.edc.client.policy.Constraints;
 import org.eclipse.tractusx.irs.edc.client.policy.Operator;
@@ -43,6 +44,7 @@ import java.util.List;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
@@ -55,6 +57,10 @@ class PolicyRepositoryImplTest {
 
     @Mock
     TraceabilityProperties traceabilityProperties;
+
+    @Mock
+    AcceptedPoliciesProvider.DefaultAcceptedPoliciesProvider defaultAcceptedPoliciesProvider;
+
 
     @Mock
     private PolicyClient policyClient;
@@ -71,6 +77,8 @@ class PolicyRepositoryImplTest {
         // then
         verify(policyClient, times(1))
                 .createPolicyFromAppConfig();
+        verify(defaultAcceptedPoliciesProvider, times(1))
+                .addAcceptedPolicies(any());
     }
 
     @Test
@@ -94,6 +102,8 @@ class PolicyRepositoryImplTest {
 
         // then
         verifyNoMoreInteractions(policyClient);
+        verify(defaultAcceptedPoliciesProvider, times(1))
+                .addAcceptedPolicies(any());
     }
 
     @Test
@@ -119,6 +129,8 @@ class PolicyRepositoryImplTest {
         // then
         verify(policyClient, times(1)).deletePolicy(traceabilityProperties.getRightOperand());
         verify(policyClient, times(1)).createPolicyFromAppConfig();
+        verify(defaultAcceptedPoliciesProvider, times(1))
+                .addAcceptedPolicies(any());
     }
 
     @Test

--- a/tx-backend/src/test/java/org/eclipse/tractusx/traceability/integration/common/support/IrsApiSupport.java
+++ b/tx-backend/src/test/java/org/eclipse/tractusx/traceability/integration/common/support/IrsApiSupport.java
@@ -172,6 +172,26 @@ public class IrsApiSupport {
         );
     }
 
+    public void irsApiReturnsExpiredPolicy() {
+        whenHttp(restitoProvider.stubServer()).match(
+                Condition.get("/irs/policies")
+        ).then(
+                Action.status(HttpStatus.OK_200),
+                Action.header("Content-Type", "application/json"),
+                restitoProvider.jsonResponseFromFile("./stubs/irs/policies/response_200_get_policies_EXPIRED.json")
+        );
+    }
+
+    public void irsApiReturnsMismatchingPolicy() {
+        whenHttp(restitoProvider.stubServer()).match(
+                Condition.get("/irs/policies")
+        ).then(
+                Action.status(HttpStatus.OK_200),
+                Action.header("Content-Type", "application/json"),
+                restitoProvider.jsonResponseFromFile("./stubs/irs/policies/response_200_get_policies_CONSTRAINTS_MISMATCHING.json")
+        );
+    }
+
     private String readFile(String filePath) throws IOException {
         // Implement reading file content from the specified filePath
         // This is a utility method to read the JSON response from a file

--- a/tx-backend/src/test/java/org/eclipse/tractusx/traceability/integration/policy/PolicyControllerIT.java
+++ b/tx-backend/src/test/java/org/eclipse/tractusx/traceability/integration/policy/PolicyControllerIT.java
@@ -96,6 +96,7 @@ class PolicyControllerIT extends IntegrationTestSpecification {
     void shouldCreatePolicy() throws JoseException {
         // GIVEN
         irsApiSupport.irsApiCreatesPolicy();
+        irsApiSupport.irsApiReturnsPolicies();
         Payload payload = Payload.builder().build();
         RegisterPolicyRequest request = new RegisterPolicyRequest(Instant.MAX, "abc", payload);
 
@@ -141,6 +142,7 @@ class PolicyControllerIT extends IntegrationTestSpecification {
     void shouldUpdatePolicy() throws JoseException {
         // GIVEN
         irsApiSupport.irsApiUpdatesPolicy();
+        irsApiSupport.irsApiReturnsPolicies();
 
         UpdatePolicyRequest request = new UpdatePolicyRequest(List.of("abc"), List.of("abc"), Instant.MAX);
 
@@ -161,6 +163,7 @@ class PolicyControllerIT extends IntegrationTestSpecification {
         // GIVEN
         String policyId = "policy1";
         irsApiSupport.irsApiDeletesPolicy(policyId);
+        irsApiSupport.irsApiReturnsPolicies();
 
         // when/then
         given()

--- a/tx-backend/src/test/resources/stubs/irs/policies/request_create_policy.json
+++ b/tx-backend/src/test/resources/stubs/irs/policies/request_create_policy.json
@@ -1,0 +1,31 @@
+{
+  "validUntil": "2024-07-04T00:00:00.000000000Z",
+  "businessPartnerNumber": "BPNL00000003CNKC",
+  "payload": {
+    "@context": {
+      "odrl": "http://www.w3.org/ns/odrl/2/"
+    },
+    "@id": "invalid-policy-2",
+    "policy": {
+      "policyId": "invalid-policy-5",
+      "createdOn": "2024-07-03T09:01:40.109000000Z",
+      "validUntil": "2024-07-04T00:00:00.000000000Z",
+      "permissions": [
+        {
+          "action": "use",
+          "constraint": {
+            "and": [
+              {
+                "leftOperand": "leftOperand",
+                "operator": {
+                  "@id": "odrl:eq"
+                },
+                "rightOperand": "rightOperand"
+              }
+            ]
+          }
+        }
+      ]
+    }
+  }
+}

--- a/tx-backend/src/test/resources/stubs/irs/policies/response_200_get_policies_CONSTRAINTS_MISMATCHING.json
+++ b/tx-backend/src/test/resources/stubs/irs/policies/response_200_get_policies_CONSTRAINTS_MISMATCHING.json
@@ -9,10 +9,10 @@
           "cx-policy" : "https://w3id.org/catenax/policy/",
           "odrl" : "http://www.w3.org/ns/odrl/2/"
         },
-        "@id" : "default-policy",
+        "@id" : "policy1",
         "policy" : {
-          "policyId" : "default-policy",
-          "createdOn" : "2024-04-03T13:04:58.000772685Z",
+          "policyId" : "policy1",
+          "createdOn" : "2023-04-03T13:04:58.000772685Z",
           "validUntil" : "2029-04-03T13:04:58.000819786Z",
           "permissions" : [
             {
@@ -24,7 +24,7 @@
                     "operator" : {
                       "@id" : "eq"
                     },
-                    "odrl:rightOperand" : "traceability:1.0"
+                    "odrl:rightOperand" : "MISMATCHING"
                   },
                   {
                     "leftOperand" : "cx-policy:UsagePurpose",

--- a/tx-backend/src/test/resources/stubs/irs/policies/response_200_get_policies_EXPIRED.json
+++ b/tx-backend/src/test/resources/stubs/irs/policies/response_200_get_policies_EXPIRED.json
@@ -1,7 +1,7 @@
 {
   "BPNL00000003CML1" : [
     {
-      "validUntil" : "2029-04-03T13:04:58.000819786Z",
+      "validUntil" : "2022-04-03T13:04:58.000819786Z",
       "payload" : {
         "@context" : {
           "@vocab" : "https://w3id.org/edc/v0.0.1/ns/",
@@ -9,11 +9,11 @@
           "cx-policy" : "https://w3id.org/catenax/policy/",
           "odrl" : "http://www.w3.org/ns/odrl/2/"
         },
-        "@id" : "default-policy",
+        "@id" : "policy1",
         "policy" : {
-          "policyId" : "default-policy",
-          "createdOn" : "2024-04-03T13:04:58.000772685Z",
-          "validUntil" : "2029-04-03T13:04:58.000819786Z",
+          "policyId" : "policy1",
+          "createdOn" : "2021-04-03T13:04:58.000772685Z",
+          "validUntil" : "2022-04-03T13:04:58.000819786Z",
           "permissions" : [
             {
               "action" : "use",


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [ ] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
