### PR TITLE
fix: make dependency check action work (efficiently)

### DIFF
--- a/.github/workflows/dependency-check.yml
+++ b/.github/workflows/dependency-check.yml
@@ -43,7 +43,7 @@ jobs:
 
       - name: Run mvn clean install
         run: |
-          mvn -B -pl tx-models,tx-backend -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn\
+          mvn -B -DskipTests -pl tx-models,tx-backend -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn\
           clean install
 
       - name: Dependency check tx-backend # possible severity values: <'fail'|'warn'|'ignore'>

--- a/.github/workflows/dependency-check.yml
+++ b/.github/workflows/dependency-check.yml
@@ -52,7 +52,7 @@ jobs:
           project: 'tx-backend'
           path: 'tx-backend'
           format: 'HTML'
-          out: 'tx-backend/target'
+          out: 'tx-backend/target/depcheck-report.html'
           args: >
             --failOnCVSS ${{ env.FAIL_BUILD_ON_CVSS }}
             --suppression ${{ env.SUPPRESSIONS_FILE }}
@@ -66,7 +66,7 @@ jobs:
           project: 'tx-models'
           path: 'tx-models'
           format: 'HTML'
-          out: 'tx-models/target'
+          out: 'tx-models/target/depcheck-report.html'
           args: >
             --failOnCVSS ${{ env.FAIL_BUILD_ON_CVSS }}
             --suppression ${{ env.SUPPRESSIONS_FILE }}
@@ -79,14 +79,14 @@ jobs:
         uses: actions/upload-artifact@master
         with:
           name: Depcheck report tx-backend
-          path: tx-backend/target
+          path: tx-backend/target/depcheck-report.html
 
       - name: Upload results for tx-models
         if: always()
         uses: actions/upload-artifact@master
         with:
           name: Depcheck report tx-models
-          path: tx-models/target
+          path: tx-models/target/depcheck-report.html
 
       - name: Add PR comment
         uses: mshick/add-pr-comment@v2

--- a/.github/workflows/dependency-check.yml
+++ b/.github/workflows/dependency-check.yml
@@ -15,7 +15,7 @@
 #
 #  SPDX-License-Identifier: Apache-2.0
 
-name: "[BE] Dependency check"
+name: "[BE] OWASP dependency check"
 
 on:
   workflow_dispatch: # Trigger manually
@@ -25,6 +25,8 @@ env:
   GHCR_REGISTRY: ghcr.io
   JAVA_VERSION: 17
   DOCKER_HUB_REGISTRY_NAMESPACE: tractusx
+  FAIL_BUILD_ON_CVSS: 7
+  SUPPRESSIONS_FILE: dependency_check/suppressions.xml
 
 jobs:
   Dependency-analysis:
@@ -39,27 +41,54 @@ jobs:
           distribution: 'temurin'
           cache: 'maven'
 
-      - name: install tx-models
-        run: mvn install -pl tx-models
+      - name: Run mvn clean install
+        run: |
+          mvn -B -pl tx-models,tx-backend -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn\
+          clean install
 
-      - name: Dependency rules report # possible severity values: <'fail'|'warn'|'ignore'>
-        run: mvn -pl tx-models,tx-backend -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn --batch-mode site -Pdependency-check
+      - name: Dependency check tx-backend # possible severity values: <'fail'|'warn'|'ignore'>
+        uses: dependency-check/Dependency-Check_Action@3102a65fd5f36d0000297576acc56a475b0de98d
+        with:
+          project: 'tx-backend'
+          path: 'tx-backend'
+          format: 'HTML'
+          out: 'tx-backend/target'
+          args: >
+            --failOnCVSS ${{ env.FAIL_BUILD_ON_CVSS }}
+            --suppression ${{ env.SUPPRESSIONS_FILE }}
+        env:
+          # actions/setup-java changes JAVA_HOME, so it needs to be reset to match the depcheck image
+          JAVA_HOME: /opt/jdk
 
-      - name: Upload Test results Tx-Backend
+      - name: Dependency check tx-models # possible severity values: <'fail'|'warn'|'ignore'>
+        uses: dependency-check/Dependency-Check_Action@3102a65fd5f36d0000297576acc56a475b0de98d
+        with:
+          project: 'tx-models'
+          path: 'tx-models'
+          format: 'HTML'
+          out: 'tx-models/target'
+          args: >
+            --failOnCVSS ${{ env.FAIL_BUILD_ON_CVSS }}
+            --suppression ${{ env.SUPPRESSIONS_FILE }}
+        env:
+          # actions/setup-java changes JAVA_HOME, so it needs to be reset to match the depcheck image
+          JAVA_HOME: /opt/jdk
+
+      - name: Upload results for tx-backend
         if: always()
         uses: actions/upload-artifact@master
         with:
           name: Depcheck report tx-backend
           path: tx-backend/target
 
-      - name: Upload Test results Tx-Models
+      - name: Upload results for tx-models
         if: always()
         uses: actions/upload-artifact@master
         with:
           name: Depcheck report tx-models
           path: tx-models/target
 
-      - name: add PR comment
+      - name: Add PR comment
         uses: mshick/add-pr-comment@v2
         if: failure()
         with:
@@ -68,7 +97,7 @@ jobs:
             One or more high/critical findings have been found during dependency check. Please check the depenency report:
             https://github.com/eclipse-tractusx/traceability-foss/actions/runs/${{ github.run_id }}
 
-      - name: add PR comment
+      - name: Add PR comment
         uses: mshick/add-pr-comment@v2
         if: success()
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ _**For better traceability add the corresponding GitHub issue number in each cha
 - #786 Introduced internal url for notification contracts.
 - #994 improved bpn edc configuration view uux
 - #1082 fix update of parts when synchronizing with IRS
+- #875 owasp dependency check tool is now used from github action image instead of maven plugin
 
 
 ### Added

--- a/pom.xml
+++ b/pom.xml
@@ -267,30 +267,6 @@ SPDX-License-Identifier: Apache-2.0
     </build>
     <profiles>
         <profile>
-            <id>dependency-check</id>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.owasp</groupId>
-                        <artifactId>dependency-check-maven</artifactId>
-                        <version>${owasp-plugin.version}</version>
-                        <configuration>
-                            <suppressionFile>dependency_check/suppressions.xml</suppressionFile>
-                            <failBuildOnCVSS>7.0</failBuildOnCVSS>
-                        </configuration>
-                        <executions>
-                            <execution>
-                                <phase>site</phase>
-                                <goals>
-                                    <goal>check</goal>
-                                </goals>
-                            </execution>
-                        </executions>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-        <profile>
             <id>spotbugs-check</id>
             <build>
                 <plugins>


### PR DESCRIPTION
## Description

This PR addresses #875.

- Removed maven profile "dependency-check" and dependency-check plugin definitions from root POM
- Changed workflow `dependency-check.yml` to use the dependency-check action, as mentioned in #875. This dramatically cuts down on workflow execution time. Additionally, the action allows for the same scanning configuration as the removed Maven profile.

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [X] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [X] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
