### PR TITLE
Fix/xxx fix release workflow

### DIFF
--- a/.github/workflows/publish-swagger-hub.yml
+++ b/.github/workflows/publish-swagger-hub.yml
@@ -2,6 +2,10 @@ name: "Publish OpenAPI to Swaggerhub"
 
 on:
   workflow_call:
+    inputs:
+      version:
+        required: true
+        type: string
 
 jobs:
   swagger-api:
@@ -26,6 +30,11 @@ jobs:
         run: |
           npm i -g swaggerhub-cli
 
+      - name: Extract versions
+        run: |
+          export VERSION="${{ inputs.version }}"
+          echo "VERSION=${VERSION}" >> "$GITHUB_ENV"
+
       - name: Update OpenAPI spec
         run: mvn test -Dsurefire.failIfNoSpecifiedTests=false -Dtest=OpenApiDocumentationIT -Dopenapi-doc.generate=true
 
@@ -42,20 +51,20 @@ jobs:
             action causes a lot of unnecessary changes which should, however, be clearly recognizable as such.
             You may safely ignore these.
 
-      # create API, will fail if exists
-      - name: Create API
-        continue-on-error: true
-        run: |
-          swaggerhub api:create ${{ env.SWAGGERHUB_USER }}/trace-x/${{ github.ref_name }} -f ${{ env.SPEC_FILE }} --visibility=public --published=unpublish
+#      # create API, will fail if exists
+#      - name: Create API
+#        continue-on-error: true
+#        run: |
+#          swaggerhub api:create ${{ env.SWAGGERHUB_USER }}/trace-x/${{ env.VERSION }} -f ${{ env.SPEC_FILE }} --visibility=public --published=unpublish
 
-      # Post the API to SwaggerHub as "unpublished", because published APIs cannot be overwritten
-      - name: Publish API Specs to SwaggerHub
-        run: |
-          if [[ ${{ github.ref_name }} != *-SNAPSHOT ]]; then
-            echo "[INFO] - no snapshot, will set the API to 'published'";
-            swaggerhub api:update ${{ env.SWAGGERHUB_USER }}/trace-x/${{ github.ref_name }} -f ${{ env.SPEC_FILE }} --visibility=public --published=publish
-            swaggerhub api:setdefault ${{ env.SWAGGERHUB_USER }}/trace-x/${{ github.ref_name }}
-          else
-            echo "[INFO] - snapshot, will set the API to 'unpublished'";
-            swaggerhub api:update ${{ env.SWAGGERHUB_USER }}/trace-x/${{ github.ref_name }} -f ${{ env.SPEC_FILE }} --visibility=public --published=unpublish
-          fi
+#      # Post the API to SwaggerHub as "unpublished", because published APIs cannot be overwritten
+#      - name: Publish API Specs to SwaggerHub
+#        run: |
+#          if [[ ${{ env.VERSION }} != *-SNAPSHOT ]]; then
+#            echo "[INFO] - no snapshot, will set the API to 'published'";
+#            swaggerhub api:update ${{ env.SWAGGERHUB_USER }}/trace-x/${{ env.VERSION }} -f ${{ env.SPEC_FILE }} --visibility=public --published=publish
+#            swaggerhub api:setdefault ${{ env.SWAGGERHUB_USER }}/trace-x/${{ env.VERSION }}
+#          else
+#            echo "[INFO] - snapshot, will set the API to 'unpublished'";
+#            swaggerhub api:update ${{ env.SWAGGERHUB_USER }}/trace-x/${{ env.VERSION }} -f ${{ env.SPEC_FILE }} --visibility=public --published=unpublish
+#          fi

--- a/.github/workflows/publish-swagger-hub.yml
+++ b/.github/workflows/publish-swagger-hub.yml
@@ -17,6 +17,11 @@ jobs:
       SPEC_FILE: docs/api/traceability-foss-backend.json
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Get updated OpenAPI spec
+        run: git pull
 
       - name: Set up JDK 17
         uses: actions/setup-java@v4

--- a/.github/workflows/publish-swagger-hub.yml
+++ b/.github/workflows/publish-swagger-hub.yml
@@ -32,7 +32,6 @@ jobs:
       - name: Create pull request for OpenAPI spec update
         uses: peter-evans/create-pull-request@v6
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
           branch: action/update-openapi-spec
           base: main
           title: "chore(OpenAPI): updated OpenAPI spec"

--- a/.github/workflows/publish-swagger-hub.yml
+++ b/.github/workflows/publish-swagger-hub.yml
@@ -14,6 +14,7 @@ jobs:
     env:
       SWAGGERHUB_API_KEY: ${{ secrets.SWAGGERHUB_API_KEY }}
       SWAGGERHUB_USER: ${{ secrets.SWAGGERHUB_USER }}
+      SPEC_FILE: docs/api/traceability-foss-backend.json
     steps:
       - uses: actions/checkout@v4
 
@@ -39,16 +40,16 @@ jobs:
       - name: Create API
         continue-on-error: true
         run: |
-          swaggerhub api:create ${{ env.SWAGGERHUB_USER }}/trace-x/${{ env.VERSION }} -f tx-backend/openapi/traceability-foss-backend.json --visibility=public --published=unpublish
+          swaggerhub api:create ${{ env.SWAGGERHUB_USER }}/trace-x/${{ env.VERSION }} -f ${{ env.SPEC_FILE }} --visibility=public --published=unpublish
 
       # Post the API to SwaggerHub as "unpublished", because published APIs cannot be overwritten
       - name: Publish API Specs to SwaggerHub
         run: |
           if [[ ${{ env.VERSION }} != *-SNAPSHOT ]]; then
             echo "[INFO] - no snapshot, will set the API to 'published'";
-            swaggerhub api:update ${{ env.SWAGGERHUB_USER }}/trace-x/${{ env.VERSION }} -f tx-backend/openapi/traceability-foss-backend.json --visibility=public --published=publish
+            swaggerhub api:update ${{ env.SWAGGERHUB_USER }}/trace-x/${{ env.VERSION }} -f ${{ env.SPEC_FILE }} --visibility=public --published=publish
             swaggerhub api:setdefault ${{ env.SWAGGERHUB_USER }}/trace-x/${{ env.VERSION }}
           else
             echo "[INFO] - snapshot, will set the API to 'unpublished'";
-            swaggerhub api:update ${{ env.SWAGGERHUB_USER }}/trace-x/${{ env.VERSION }} -f tx-backend/openapi/traceability-foss-backend.json --visibility=public --published=unpublish
+            swaggerhub api:update ${{ env.SWAGGERHUB_USER }}/trace-x/${{ env.VERSION }} -f ${{ env.SPEC_FILE }} --visibility=public --published=unpublish
           fi

--- a/.github/workflows/publish-swagger-hub.yml
+++ b/.github/workflows/publish-swagger-hub.yml
@@ -33,9 +33,9 @@ jobs:
         uses: peter-evans/create-pull-request@v6
         with:
           branch: action/update-openapi-spec
+          commit-message: "chore(release): updated OpenAPI spec"
           base: main
-          title: "chore(OpenAPI): updated OpenAPI spec"
-          labels: automated
+          title: "chore(release): updated OpenAPI spec"
           delete-branch: true
           body: |
             This PR updates the OpenAPI spec. Please check whether the update was performed correctly. Unfortunately, this

--- a/.github/workflows/publish-swagger-hub.yml
+++ b/.github/workflows/publish-swagger-hub.yml
@@ -2,11 +2,6 @@ name: "Publish OpenAPI to Swaggerhub"
 
 on:
   workflow_call:
-    inputs:
-      version:
-        required: true
-        description: Version that will be published to Swaggerhub
-        type: string
 
 jobs:
   swagger-api:
@@ -17,11 +12,6 @@ jobs:
       SPEC_FILE: docs/api/traceability-foss-backend.json
     steps:
       - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Get updated OpenAPI spec
-        run: git pull
 
       - name: Set up JDK 17
         uses: actions/setup-java@v4
@@ -36,25 +26,37 @@ jobs:
         run: |
           npm i -g swaggerhub-cli
 
-      - name: Extract versions
-        run: |
-          export VERSION="${{ inputs.version }}"
-          echo "VERSION=${VERSION}" >> "$GITHUB_ENV"
+      - name: Update OpenAPI spec
+        run: mvn test -Dsurefire.failIfNoSpecifiedTests=false -Dtest=OpenApiDocumentationIT -Dopenapi-doc.generate=true
+
+      - name: Create pull request for OpenAPI spec update
+        uses: peter-evans/create-pull-request@v6
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          branch: action/update-openapi-spec
+          base: main
+          title: "chore(OpenAPI): updated OpenAPI spec"
+          labels: automated
+          delete-branch: true
+          body: |
+            This PR updates the OpenAPI spec. Please check whether the update was performed correctly. Unfortunately, this
+            action causes a lot of unnecessary changes which should, however, be clearly recognizable as such.
+            You may safely ignore these.
 
       # create API, will fail if exists
       - name: Create API
         continue-on-error: true
         run: |
-          swaggerhub api:create ${{ env.SWAGGERHUB_USER }}/trace-x/${{ env.VERSION }} -f ${{ env.SPEC_FILE }} --visibility=public --published=unpublish
+          swaggerhub api:create ${{ env.SWAGGERHUB_USER }}/trace-x/${{ github.ref_name }} -f ${{ env.SPEC_FILE }} --visibility=public --published=unpublish
 
       # Post the API to SwaggerHub as "unpublished", because published APIs cannot be overwritten
       - name: Publish API Specs to SwaggerHub
         run: |
-          if [[ ${{ env.VERSION }} != *-SNAPSHOT ]]; then
+          if [[ ${{ github.ref_name }} != *-SNAPSHOT ]]; then
             echo "[INFO] - no snapshot, will set the API to 'published'";
-            swaggerhub api:update ${{ env.SWAGGERHUB_USER }}/trace-x/${{ env.VERSION }} -f ${{ env.SPEC_FILE }} --visibility=public --published=publish
-            swaggerhub api:setdefault ${{ env.SWAGGERHUB_USER }}/trace-x/${{ env.VERSION }}
+            swaggerhub api:update ${{ env.SWAGGERHUB_USER }}/trace-x/${{ github.ref_name }} -f ${{ env.SPEC_FILE }} --visibility=public --published=publish
+            swaggerhub api:setdefault ${{ env.SWAGGERHUB_USER }}/trace-x/${{ github.ref_name }}
           else
             echo "[INFO] - snapshot, will set the API to 'unpublished'";
-            swaggerhub api:update ${{ env.SWAGGERHUB_USER }}/trace-x/${{ env.VERSION }} -f ${{ env.SPEC_FILE }} --visibility=public --published=unpublish
+            swaggerhub api:update ${{ env.SWAGGERHUB_USER }}/trace-x/${{ github.ref_name }} -f ${{ env.SPEC_FILE }} --visibility=public --published=unpublish
           fi

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -8,96 +8,12 @@ on:
 
 env:
   JAVA_VERSION: 17
-  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
 jobs:
   release:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Set up JDK
-        uses: actions/setup-java@v4
-        with:
-          java-version: '${{ env.JAVA_VERSION }}'
-          distribution: 'temurin'
-          cache: 'maven'
-
-      - name: Update OpenAPI spec
-        run: mvn test -Dsurefire.failIfNoSpecifiedTests=false -Dtest=OpenApiDocumentationIT -Dopenapi-doc.generate=true
-
-      - name: Determine release branch name
-        id: determine-branch-name
-        run: |
-          name=$(git branch -a | grep -Eoi "release/${{ github.ref_name }}" || echo "")
-          if [[ -z $name ]]; then
-            echo "No branch release/${{ github.ref_name }} or Release/${{ github.ref_name }} found, aborting..."
-            exit 1
-          fi
-          echo "branch-name=$name" >> "$GITHUB_OUTPUT"
-          echo "Release branch name is $name"
-
-      - name: Create pull request
-        id: create-openapi-pr
-        uses: peter-evans/create-pull-request@v6
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          branch: action/update-openapi-spec
-          base: ${{ steps.determine-branch-name.outputs.branch-name }}
-          title: "chore(OpenAPI): updated OpenAPI spec"
-          labels: automated
-          delete-branch: true
-          body: |
-            This PR updates the OpenAPI spec. Please check whether the update was performed correctly. Unfortunately, this
-            action causes a lot of nonsensical changes which should, however, be clearly recognizable as such.
-            You can safely ignore these.
-
-      - name: Wait for pull request merge
-        run: |
-          pull_request_number=${{ steps.create-openapi-pr.outputs.pull-request-number }}
-          pull_request_merged="False"
-          seconds_waited_for_merge=0
-          # set duration between api requests
-          sleep_interval_length=5 # seconds
-          timeout_in_minutes=15
-
-          echo "Waiting for you to merge PR #$pull_request_number which contains the updated OpenAPI spec."
-
-          while [[ "$pull_request_merged" == "False" ]]
-          do
-            # give some time to merge pull request
-            sleep "$sleep_interval_length"s
-
-            # retrieve pr status using GH API's pull requests endpoint with GH CLI
-            pr_status=$(gh pr view $pull_request_number --json state --jq ".state")
-
-            case $pr_status in
-
-              MERGED)
-                pull_request_merged="True"
-                echo "PR #$pull_request_number merged, continuing the workflow."
-                ;;
-
-              OPEN)
-                seconds_waited_for_merge=$((seconds_waited_for_merge+sleep_interval_length))
-
-                # abort workflow when having waited for more than allowed time
-                if [[ $seconds_waited_for_merge -gt $((timeout_in_minutes*60)) ]]; then
-                  echo "Timeout waiting for merge of PR #$pull_request_number, aborting the workflow."
-                  exit 1
-                fi
-                ;;
-
-              CLOSED)
-                echo "PR #$pull_request_number was closed, aborting the workflow."
-                exit 1
-                ;;
-
-            esac
-
-          done
 
       - name: Calculate Helm release version from CHANGELOG
         run: echo HELM_VERSION=$(cat charts/traceability-foss/CHANGELOG.md | sed -n 's/.*\[\([0-9]\+\.[0-9]\+\.[0-9]\+\)\].*/\1/p' | head -n 1) >> $GITHUB_ENV
@@ -184,6 +100,4 @@ jobs:
     needs:
       - release
     uses: ./.github/workflows/publish-swagger-hub.yml
-    with:
-      version: ${{ github.ref_name }}
     secrets: inherit

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -8,6 +8,7 @@ on:
 
 env:
   JAVA_VERSION: 17
+  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
 jobs:
   release:
@@ -100,6 +101,7 @@ jobs:
           echo "Branch name is $name"
 
       - name: Create pull request
+        id: create-pr
         uses: peter-evans/create-pull-request@v6
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -112,6 +114,51 @@ jobs:
             This PR updates the OpenAPI spec. Please check whether the update was performed correctly. Unfortunately, this
             action causes a lot of nonsensical changes which should, however, be clearly recognizable as such.
             You can safely ignore these.
+
+      - name: Wait for pull request merge
+        run: |
+          pull_request_number=${{ steps.create-pr.outputs.pull-request-number }}
+          pull_request_merged="False"
+          seconds_waited_for_merge=0
+          # set duration between api requests
+          sleep_interval_length=5 # seconds
+          timeout_in_minutes=15
+
+          echo "Waiting for you to merge PR #$pull_request_number which contains the updated OpenAPI spec."
+
+          while [[ "$pull_request_merged" == "False" ]]
+          do
+            # give some time to merge pull request
+            sleep "$sleep_interval_length"s
+
+            # retrieve pr status using GH API's pull requests endpoint with GH CLI
+            pr_status=$(gh pr view $pull_request_number --json state --jq ".state")
+
+            case $pr_status in
+
+              MERGED)
+                pull_request_merged="True"
+                echo "PR #$pull_request_number merged, continuing the workflow."
+                ;;
+
+              OPEN)
+                seconds_waited_for_merge=$((seconds_waited_for_merge+sleep_interval_length))
+
+                # abort workflow when having waited for more than allowed time
+                if [[ $seconds_waited_for_merge -gt $((timeout_in_minutes*60)) ]]; then
+                  echo "Timeout waiting for merge of PR #$pull_request_number, aborting the workflow."
+                  exit 1
+                fi
+                ;;
+
+              CLOSED)
+                echo "PR #$pull_request_number was closed, aborting the workflow."
+                exit 1
+                ;;
+
+            esac
+
+          done
 
       - name: Get previous version
         run: echo PREVIOUS_VERSION=$(git tag | grep -E ^[0-9]+\\.[0-9]+\\.[0-9]+ | tail -2 | head -n +1) >> $GITHUB_ENV

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -14,6 +14,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Set up JDK
         uses: actions/setup-java@v4

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -100,4 +100,6 @@ jobs:
     needs:
       - release
     uses: ./.github/workflows/publish-swagger-hub.yml
+    with:
+      version: ${{ github.ref_name }}
     secrets: inherit

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -92,12 +92,3 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           body: ${{ env.CHANGELOG }}
-
-  publish-to-swaggerhub:
-    name: "Publish OpenAPI spec to Swaggerhub"
-    permissions:
-      contents: read
-    needs:
-      - release
-    uses: ./.github/workflows/update-openapi-spec.yml
-    secrets: inherit

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -25,6 +25,80 @@ jobs:
           distribution: 'temurin'
           cache: 'maven'
 
+      - name: Update OpenAPI spec
+        run: mvn test -Dsurefire.failIfNoSpecifiedTests=false -Dtest=OpenApiDocumentationIT -Dopenapi-doc.generate=true
+
+      - name: Determine release branch name
+        id: determine-branch-name
+        run: |
+          name=$(git branch -a | grep -Eoi "release/${{ github.ref_name }}" || echo "")
+          if [[ -z $name ]]; then
+            echo "No branch release/${{ github.ref_name }} or Release/${{ github.ref_name }} found, aborting..."
+            exit 1
+          fi
+          echo "branch-name=$name" >> "$GITHUB_OUTPUT"
+          echo "Release branch name is $name"
+
+      - name: Create pull request
+        id: create-openapi-pr
+        uses: peter-evans/create-pull-request@v6
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          branch: action/update-openapi-spec
+          base: ${{ steps.determine-branch-name.outputs.branch-name }}
+          title: "chore(OpenAPI): updated OpenAPI spec"
+          labels: automated
+          delete-branch: true
+          body: |
+            This PR updates the OpenAPI spec. Please check whether the update was performed correctly. Unfortunately, this
+            action causes a lot of nonsensical changes which should, however, be clearly recognizable as such.
+            You can safely ignore these.
+
+      - name: Wait for pull request merge
+        run: |
+          pull_request_number=${{ steps.create-openapi-pr.outputs.pull-request-number }}
+          pull_request_merged="False"
+          seconds_waited_for_merge=0
+          # set duration between api requests
+          sleep_interval_length=5 # seconds
+          timeout_in_minutes=15
+
+          echo "Waiting for you to merge PR #$pull_request_number which contains the updated OpenAPI spec."
+
+          while [[ "$pull_request_merged" == "False" ]]
+          do
+            # give some time to merge pull request
+            sleep "$sleep_interval_length"s
+
+            # retrieve pr status using GH API's pull requests endpoint with GH CLI
+            pr_status=$(gh pr view $pull_request_number --json state --jq ".state")
+
+            case $pr_status in
+
+              MERGED)
+                pull_request_merged="True"
+                echo "PR #$pull_request_number merged, continuing the workflow."
+                ;;
+
+              OPEN)
+                seconds_waited_for_merge=$((seconds_waited_for_merge+sleep_interval_length))
+
+                # abort workflow when having waited for more than allowed time
+                if [[ $seconds_waited_for_merge -gt $((timeout_in_minutes*60)) ]]; then
+                  echo "Timeout waiting for merge of PR #$pull_request_number, aborting the workflow."
+                  exit 1
+                fi
+                ;;
+
+              CLOSED)
+                echo "PR #$pull_request_number was closed, aborting the workflow."
+                exit 1
+                ;;
+
+            esac
+
+          done
+
       - name: Calculate Helm release version from CHANGELOG
         run: echo HELM_VERSION=$(cat charts/traceability-foss/CHANGELOG.md | sed -n 's/.*\[\([0-9]\+\.[0-9]\+\.[0-9]\+\)\].*/\1/p' | head -n 1) >> $GITHUB_ENV
 
@@ -85,80 +159,6 @@ jobs:
             This PR prepares the Helm chart release for version ${{ env.HELM_VERSION }}.
             Please check whether the Chart was updated correctly and that the CHANGELOG contains the relevant information
             for this release. Also, make sure that the values.yaml is correct before merging this PR.
-
-      - name: Update OpenAPI spec
-        run: mvn test -Dsurefire.failIfNoSpecifiedTests=false -Dtest=OpenApiDocumentationIT -Dopenapi-doc.generate=true
-
-      - name: Determine release branch name
-        id: determine-branch-name
-        run: |
-          name=$(git branch -a | grep -Eoi "release/${{ github.ref_name }}" || echo "")
-          if [[ -z $name ]]; then
-            echo "No branch release/${{ github.ref_name }} or Release/${{ github.ref_name }} found, aborting..."
-            exit 1
-          fi
-          echo "branch-name=$name" >> "$GITHUB_OUTPUT"
-          echo "Branch name is $name"
-
-      - name: Create pull request
-        id: create-pr
-        uses: peter-evans/create-pull-request@v6
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          branch: action/update-openapi-spec
-          base: ${{ steps.determine-branch-name.outputs.branch-name }}
-          title: "chore(OpenAPI): updated OpenAPI spec"
-          labels: automated
-          delete-branch: true
-          body: |
-            This PR updates the OpenAPI spec. Please check whether the update was performed correctly. Unfortunately, this
-            action causes a lot of nonsensical changes which should, however, be clearly recognizable as such.
-            You can safely ignore these.
-
-      - name: Wait for pull request merge
-        run: |
-          pull_request_number=${{ steps.create-pr.outputs.pull-request-number }}
-          pull_request_merged="False"
-          seconds_waited_for_merge=0
-          # set duration between api requests
-          sleep_interval_length=5 # seconds
-          timeout_in_minutes=15
-
-          echo "Waiting for you to merge PR #$pull_request_number which contains the updated OpenAPI spec."
-
-          while [[ "$pull_request_merged" == "False" ]]
-          do
-            # give some time to merge pull request
-            sleep "$sleep_interval_length"s
-
-            # retrieve pr status using GH API's pull requests endpoint with GH CLI
-            pr_status=$(gh pr view $pull_request_number --json state --jq ".state")
-
-            case $pr_status in
-
-              MERGED)
-                pull_request_merged="True"
-                echo "PR #$pull_request_number merged, continuing the workflow."
-                ;;
-
-              OPEN)
-                seconds_waited_for_merge=$((seconds_waited_for_merge+sleep_interval_length))
-
-                # abort workflow when having waited for more than allowed time
-                if [[ $seconds_waited_for_merge -gt $((timeout_in_minutes*60)) ]]; then
-                  echo "Timeout waiting for merge of PR #$pull_request_number, aborting the workflow."
-                  exit 1
-                fi
-                ;;
-
-              CLOSED)
-                echo "PR #$pull_request_number was closed, aborting the workflow."
-                exit 1
-                ;;
-
-            esac
-
-          done
 
       - name: Get previous version
         run: echo PREVIOUS_VERSION=$(git tag | grep -E ^[0-9]+\\.[0-9]+\\.[0-9]+ | tail -2 | head -n +1) >> $GITHUB_ENV

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -90,7 +90,7 @@ jobs:
         id: determine-branch-name
         run: |
           name=$(git branch -a | grep -Eoi "release/${{ github.ref_name }}" || echo "")
-          if [[ -z name ]]; then
+          if [[ -z $name ]]; then
             echo "No branch release/${{ github.ref_name }} or Release/${{ github.ref_name }} found, aborting..."
             exit 1
           fi

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -99,7 +99,7 @@ jobs:
       contents: read
     needs:
       - release
-    uses: ./.github/workflows/publish-swagger-hub.yml
+    uses: ./.github/workflows/update-openapi-spec.yml
     with:
       version: ${{ github.ref_name }}
     secrets: inherit

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -94,14 +94,15 @@ jobs:
             echo "No branch release/${{ github.ref_name }} or Release/${{ github.ref_name }} found, aborting..."
             exit 1
           fi
-          echo "name=$name" >> "$GITHUB_OUTPUT"
+          echo "branch-name=$name" >> "$GITHUB_OUTPUT"
+          echo "Branch name is $name"
 
       - name: Create pull request
         uses: peter-evans/create-pull-request@v6
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           branch: action/update-openapi-spec
-          base: ${{ steps.determine-branch-name.outputs.name }}
+          base: ${{ steps.determine-branch-name.outputs.branch-name }}
           title: "chore(OpenAPI): updated OpenAPI spec"
           labels: automated
           delete-branch: true

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -83,22 +83,33 @@ jobs:
             Please check whether the Chart was updated correctly and that the CHANGELOG contains the relevant information
             for this release. Also, make sure that the values.yaml is correct before merging this PR.
 
- #     - name: Update OpenAPI spec
- #       run: mvn test -Dsurefire.failIfNoSpecifiedTests=false -Dtest=OpenApiDocumentationIT -Dopenapi-doc.generate=true
-#
- #     - name: Create pull request
- #       uses: peter-evans/create-pull-request@v6
- #       with:
- #         token: ${{ secrets.GITHUB_TOKEN }}
- #         branch: action/update-openapi-spec
- #         title: "chore(OpenAPI): updated OpenAPI spec"
- #         labels: automated
- #         delete-branch: true
- #         body: |
- #           This PR updates the OpenAPI spec. Please check whether the spec was updated correctly. Unfortunately, this
- #           action causes a lot of nonsensical changes which should, however, be clearly recognizable.
- #           You can safely ignore these.
-#
+      - name: Update OpenAPI spec
+        run: mvn test -Dsurefire.failIfNoSpecifiedTests=false -Dtest=OpenApiDocumentationIT -Dopenapi-doc.generate=true
+
+      - name: Determine release branch name
+        id: determine-branch-name
+        run: |
+          name=$(git branch -a | grep -Eoi "release/${{ github.ref_name }}" || echo "")
+          if [[ -z name ]]; then
+            echo "No branch release/${{ github.ref_name }} or Release/${{ github.ref_name }} found, aborting..."
+            exit 1
+          fi
+          echo "name=$name" >> "$GITHUB_OUTPUT"
+
+      - name: Create pull request
+        uses: peter-evans/create-pull-request@v6
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          branch: action/update-openapi-spec
+          base: ${{ steps.determine-branch-name.outputs.name }}
+          title: "chore(OpenAPI): updated OpenAPI spec"
+          labels: automated
+          delete-branch: true
+          body: |
+            This PR updates the OpenAPI spec. Please check whether the update was performed correctly. Unfortunately, this
+            action causes a lot of nonsensical changes which should, however, be clearly recognizable as such.
+            You can safely ignore these.
+
       - name: Get previous version
         run: echo PREVIOUS_VERSION=$(git tag | grep -E ^[0-9]+\\.[0-9]+\\.[0-9]+ | tail -2 | head -n +1) >> $GITHUB_ENV
 

--- a/.github/workflows/update-openapi-spec.yml
+++ b/.github/workflows/update-openapi-spec.yml
@@ -1,4 +1,4 @@
-name: "Publish OpenAPI to Swaggerhub"
+name: "Update OpenAPI spec"
 
 on:
   workflow_call:
@@ -22,34 +22,35 @@ jobs:
         with:
           java-version: '17'
           distribution: 'temurin'
-
-      - name: Setup node
-        uses: actions/setup-node@v4
-
-      - name: Install Swagger CLI
-        run: |
-          npm i -g swaggerhub-cli
-
-      - name: Extract versions
-        run: |
-          export VERSION="${{ inputs.version }}"
-          echo "VERSION=${VERSION}" >> "$GITHUB_ENV"
+          cache: 'maven'
 
       - name: Update OpenAPI spec
-        run: mvn test -Dsurefire.failIfNoSpecifiedTests=false -Dtest=OpenApiDocumentationIT -Dopenapi-doc.generate=true
+        run: mvn test -B -Dsurefire.failIfNoSpecifiedTests=false -Dtest=OpenApiDocumentationIT -Dopenapi-doc.generate=true
 
       - name: Create pull request for OpenAPI spec update
         uses: peter-evans/create-pull-request@v6
         with:
-          branch: action/update-openapi-spec
           commit-message: "chore(release): updated OpenAPI spec"
+          branch: chore/update-openapi-spec
           base: main
-          title: "chore(release): updated OpenAPI spec"
           delete-branch: true
+          title: "chore: update OpenAPI spec for release ${{ inputs.version }}"
           body: |
             This PR updates the OpenAPI spec. Please check whether the update was performed correctly. Unfortunately, this
             action causes a lot of unnecessary changes which should, however, be clearly recognizable as such.
             You may safely ignore these.
+
+#      - name: Setup node
+#        uses: actions/setup-node@v4
+#
+#      - name: Install Swagger CLI
+#        run: |
+#          npm i -g swaggerhub-cli
+
+#      - name: Extract versions
+#        run: |
+#          export VERSION="${{ inputs.version }}"
+#          echo "VERSION=${VERSION}" >> "$GITHUB_ENV"
 
 #      # create API, will fail if exists
 #      - name: Create API

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -35,11 +35,12 @@ Trace-X using semantic versioning three-part version number. https://semver.org/
 # Release an app
 
 ### Prerequisite:
-- Make sure eclipse / catena git repositories are in sync
+- Make sure the Eclipse Git repository is in sync
 - Before releasing Trace-X, it is required to go through the [IRS Library Release](#irs-library-release) steps
 
 ### IRS Library Release
 The goal is to not use a -SNAPSHOT version in the Trace-X Release.
+
 1) Check if the irs-registry-client version has a -SNAPSHOT suffix:  [IRS Repo](https://github.com/eclipse-tractusx/item-relationship-service/blob/f731e2e7403b738d516a7a25b19c756cc32b04f3/pom.xml#L76)
 2) If yes, continue with the next steps. If no, skip to the [Trace-X Release process](#trace-x-release-process)
 3) Click on the [Update irs-registry-client Version workflow](https://github.com/eclipse-tractusx/item-relationship-service/actions/workflows/update-registry-library.yaml).
@@ -51,16 +52,16 @@ The goal is to not use a -SNAPSHOT version in the Trace-X Release.
 ### Trace-X Release process
 
 1) Decide which to which version the release trace-x will be incremented. Following shows example for releasing a version 1.0.0
-2) Create and Checkout release branch on catena /release/1.0.0. The name must always be exactly `/release/<releaseVersion>`.
+2) Create and checkout release branch /release/1.0.0. The name must always be exactly `/release/<releaseVersion>`.
 3) Optional: If [IRS Library Release](#irs-library-release) was needed:
-   1) If the action of [IRS Library Release](#irs-library-release) step 7 was executed successfully
-   2) Update <irs-client-lib.version> in the above created release
+    1) If the action of [IRS Library Release](#irs-library-release) step 7 was executed successfully
+    2) Update <irs-client-lib.version> in the above created release
 4) Edit changelog: Align the new version (1.0.0) with the changes and add a new UNRELEASED section
 5) Edit /charts/traceability-foss/CHANGELOG.md
 6) Add an Entry for an incremented (patch) version (1.0.0 -> 1.0.1)
 7) Update the [Compatability Matrix](https://github.com/eclipse-tractusx/traceability-foss/blob/main/COMPATIBILITY_MATRIX.md) with a new entry for the release version
-8) Push onto /release/1.0.0 catena and eclipse
-9) Open Release App Page Catena: https://github.com/eclipse-tractusx/traceability-foss/releases
+8) Push onto /release/1.0.0
+9) Open releases page: https://github.com/eclipse-tractusx/traceability-foss/releases
 10) Draft a new release
 11) On dropdown choose a tag - use the version 1.0.0 (Create new tag will appear - select it)
 12) On dropdown target use your /release/1.0.0
@@ -68,16 +69,14 @@ The goal is to not use a -SNAPSHOT version in the Trace-X Release.
 14) Description = Changelog Content of app
 15) Checkbox set as latest release
 16) Verify that GitHub action [Release](https://github.com/eclipse-tractusx/traceability-foss/actions/workflows/release.yaml) generation has been triggered
-17) Verify that two automatic pull request have been opened
-    - `Prepare Helm release for next version` with base `main`
-    - `chore(OpenAPI): updated OpenAPI spec` with the release branch as base
-18) Validate that the changes within the pull requests are correct
-19) Merge aforementioned pull requests
-20) Merge release branch into main (when merging make sure to restore release branch since it should stay)
-21) Open the GitHub action for helm release generation: https://github.com/eclipse-tractusx/traceability-foss/actions/workflows/helm-chart-release.yaml
-22) Execute it from main branch
-23) Validate that the helm charts release has been generated within the release page
-24) Create a new branch from release/1.0.0 and name it release/helm-environments-1.0.0 (helm app version not chart version)
-25) Repeat step 9 to 24 for tractus-x: [GitHub Releases page](https://github.com/eclipse-tractusx/traceability-foss/releases)
-26) Sync catena and eclipse main branch
-27) Create a message in the Trace-X channel of the Eclipse Foundation Chat to notify the community about the new release (add a link to the tractus-x release)
+17) Verify that following pull request has been opened: `chore(OpenAPI): updated OpenAPI spec`, with the release branch as its base
+18) Merge the aforementioned pull request within 15 minutes, the workflow is going to wait for the merge. Should you fail to perform
+    the merge in that time or if the pull request gets closed, the workflow will fail.
+19) Verify that another pull request has been opened: `Prepare Helm release for next version` with base `main`
+20) Merge aforementioned pull request.
+21) Merge release branch into main (when merging make sure to restore release branch since it should stay)
+22) Open the GitHub action for helm release generation: https://github.com/eclipse-tractusx/traceability-foss/actions/workflows/helm-chart-release.yaml
+23) Execute it from main branch
+24) Validate that the helm charts release has been generated within the release page
+25) Create a new branch from release/1.0.0 and name it release/helm-environments-1.0.0 (helm app version not chart version)
+26) Create a message in the Trace-X channel of the Eclipse Foundation Chat to notify the community about the new release (add a link to the tractus-x release)

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -51,7 +51,7 @@ The goal is to not use a -SNAPSHOT version in the Trace-X Release.
 ### Trace-X Release process
 
 1) Decide which to which version the release trace-x will be incremented. Following shows example for releasing a version 1.0.0
-2) Create and Checkout release branch on catena /release/1.0.0
+2) Create and Checkout release branch on catena /release/1.0.0. The name must always be exactly `/release/<releaseVersion>`.
 3) Optional: If [IRS Library Release](#irs-library-release) was needed:
    1) If the action of [IRS Library Release](#irs-library-release) step 7 was executed successfully
    2) Update <irs-client-lib.version> in the above created release
@@ -68,9 +68,11 @@ The goal is to not use a -SNAPSHOT version in the Trace-X Release.
 14) Description = Changelog Content of app
 15) Checkbox set as latest release
 16) Verify that GitHub action [Release](https://github.com/eclipse-tractusx/traceability-foss/actions/workflows/release.yaml) generation has been triggered
-17) Verify that an automatic pull request has been opened (Prepare Helm release for next version)
-18) Validate that the versions within that pull requests are correct
-19) Merge pull request (Prepare Helm release for next version)
+17) Verify that two automatic pull request have been opened
+    - `Prepare Helm release for next version` with base `main`
+    - `chore(OpenAPI): updated OpenAPI spec` with the release branch as base
+18) Validate that the changes within the pull requests are correct
+19) Merge aforementioned pull requests
 20) Merge release branch into main (when merging make sure to restore release branch since it should stay)
 21) Open the GitHub action for helm release generation: https://github.com/eclipse-tractusx/traceability-foss/actions/workflows/helm-chart-release.yaml
 22) Execute it from main branch

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -69,14 +69,13 @@ The goal is to not use a -SNAPSHOT version in the Trace-X Release.
 14) Description = Changelog Content of app
 15) Checkbox set as latest release
 16) Verify that GitHub action [Release](https://github.com/eclipse-tractusx/traceability-foss/actions/workflows/release.yaml) generation has been triggered
-17) Verify that following pull request has been opened: `chore(OpenAPI): updated OpenAPI spec`, with the release branch as its base
-18) Merge the aforementioned pull request within 15 minutes, the workflow is going to wait for the merge. Should you fail to perform
-    the merge in that time or if the pull request gets closed, the workflow will fail.
-19) Verify that another pull request has been opened: `Prepare Helm release for next version` with base `main`
-20) Merge aforementioned pull request.
-21) Merge release branch into main (when merging make sure to restore release branch since it should stay)
-22) Open the GitHub action for helm release generation: https://github.com/eclipse-tractusx/traceability-foss/actions/workflows/helm-chart-release.yaml
-23) Execute it from main branch
-24) Validate that the helm charts release has been generated within the release page
-25) Create a new branch from release/1.0.0 and name it release/helm-environments-1.0.0 (helm app version not chart version)
-26) Create a message in the Trace-X channel of the Eclipse Foundation Chat to notify the community about the new release (add a link to the tractus-x release)
+17) Verify that these pull requests have been opened:
+        - `Prepare Helm release for next version`
+        - `chore(OpenAPI): updated OpenAPI spec`
+18) Verify and merge the changes proposed in the requests
+19) Merge release branch into main (when merging make sure to restore release branch since it should stay)
+20) Open the GitHub action for helm release generation: https://github.com/eclipse-tractusx/traceability-foss/actions/workflows/helm-chart-release.yaml
+21) Execute it from main branch
+22) Validate that the helm charts release has been generated within the release page
+23) Create a new branch from release/1.0.0 and name it release/helm-environments-1.0.0 (helm app version not chart version)
+24) Create a message in the Trace-X channel of the Eclipse Foundation Chat to notify the community about the new release (add a link to the tractus-x release)

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -8,12 +8,14 @@
 Trace-X using semantic versioning three-part version number. https://semver.org/
 
 ## Major Release
+
 * If there are any incompatible API changes.
 * Changes with high impact
 * Contains new features and changes with critical business impact.
 * Full regression tests are covered.
 
 ## Minor Release
+
 * Add functionality in a backwards compatible manner
 * Features (backwards compatible has to be ensured)
 * Minor release does not add features or changes with critical business impact.
@@ -23,6 +25,7 @@ Trace-X using semantic versioning three-part version number. https://semver.org/
 * Operational risks should be low.
 
 ## Bug fix / Patch Release
+
 * Backwards compatible bug fixes
 * Bug fixes and Hotfixes
 * Covers Bug fixes and changes with no critical business impact.
@@ -30,15 +33,18 @@ Trace-X using semantic versioning three-part version number. https://semver.org/
 * INT Test environment should be stable. No changes on depending on systems required. No changes on consumer side necessary.
 
 ## Tag
+
 * Defined software state.
 
 # Release an app
 
 ### Prerequisite:
+
 - Make sure the Eclipse Git repository is in sync
 - Before releasing Trace-X, it is required to go through the [IRS Library Release](#irs-library-release) steps
 
 ### IRS Library Release
+
 The goal is to not use a -SNAPSHOT version in the Trace-X Release.
 
 1) Check if the irs-registry-client version has a -SNAPSHOT suffix:  [IRS Repo](https://github.com/eclipse-tractusx/item-relationship-service/blob/f731e2e7403b738d516a7a25b19c756cc32b04f3/pom.xml#L76)
@@ -69,13 +75,12 @@ The goal is to not use a -SNAPSHOT version in the Trace-X Release.
 14) Description = Changelog Content of app
 15) Checkbox set as latest release
 16) Verify that GitHub action [Release](https://github.com/eclipse-tractusx/traceability-foss/actions/workflows/release.yaml) generation has been triggered
-17) Verify that these pull requests have been opened:
-        - `Prepare Helm release for next version`
-        - `chore(OpenAPI): updated OpenAPI spec`
-18) Verify and merge the changes proposed in the requests
-19) Merge release branch into main (when merging make sure to restore release branch since it should stay)
-20) Open the GitHub action for helm release generation: https://github.com/eclipse-tractusx/traceability-foss/actions/workflows/helm-chart-release.yaml
-21) Execute it from main branch
-22) Validate that the helm charts release has been generated within the release page
-23) Create a new branch from release/1.0.0 and name it release/helm-environments-1.0.0 (helm app version not chart version)
-24) Create a message in the Trace-X channel of the Eclipse Foundation Chat to notify the community about the new release (add a link to the tractus-x release)
+17) Verify that this pull request has been opened: `Prepare Helm release for next version` and merge it
+18) Execute GitHub action [Update OpenAPI spec](https://github.com/eclipse-tractusx/traceability-foss/actions/workflows/update-openapi-spec.yml)
+19) Verify that this pull request has been opened: `chore: update OpenAPI spec` and merge it
+20) Merge release branch into main (when merging make sure to restore release branch since it should stay)
+21) Open the GitHub action for helm release generation: https://github.com/eclipse-tractusx/traceability-foss/actions/workflows/helm-chart-release.yaml
+22) Execute it from main branch
+23) Validate that the helm charts release has been generated within the release page
+24) Create a new branch from release/1.0.0 and name it release/helm-environments-1.0.0 (helm app version not chart version)
+25) Create a message in the Trace-X channel of the Eclipse Foundation Chat to notify the community about the new release (add a link to the tractus-x release)


### PR DESCRIPTION
## Description
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->

Previously, the release workflow crashed due to some errors. These errors were:

- The workflow checks out a tag and tries to use the `create-pull-request` action. However, the action had no information which branch to choose as base of the PR.
- The workflow publishing the openapi spec tried to read the spec file from a location which no longer exists.

1. This PR fixes these errors.

2. Additionally, the release process has changed to accomodate the new way of generating the OpenAPI spec mentioned in #1107. The workflow used for publishing an updated OpenAPI spec no longer exists, instead the new workflow `Update OpenAPI spec` needs to be manually executed during the release process which updates the spec and opens a PR from it. The release documentation in `RELEASE.md` has been adapted accordingly.

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [X] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [X] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
