### PR TITLE
chore(doc):[#000] update legal notice to 2024

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 _**For better traceability add the corresponding GitHub issue number in each changelog entry, please.**_
 ## [UNRELEASED - DD.MM.YYYY]
 ### Changed
+- XXX update legal notice for documents arc42, admin and user manual to years 2024
 - #965 Implement proxy functionality of the IRS policy store
 - #962 Changed notification model to new one in frontend/backend
 - #962 Removed initial notification message for notification flow

--- a/docs/src/docs/administration/administration-guide.adoc
+++ b/docs/src/docs/administration/administration-guide.adoc
@@ -6,10 +6,10 @@ This work is licensed under the [Apache-2.0](https://www.apache.org/licenses/LIC
 
 * SPDX-License-Identifier: Apache-2.0
 * Licence Path: https://creativecommons.org/licenses/by/4.0/legalcode
-* Copyright (c) 2021,2022,2023 Contributors to the Eclipse Foundation
+* Copyright (c) 2021,2022,2023, 2024 Contributors to the Eclipse Foundation
 * Copyright (c) 2022, 2023 ZF Friedrichshafen AG
 * Copyright (c) 2022 ISTOS GmbH
-* Copyright (c) 2022, 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+* Copyright (c) 2022, 2023, 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
 * Copyright (c) 2022,2023 BOSCH AG
 
 * Source URL: https://github.com/eclipse-tractusx/traceability-foss

--- a/docs/src/docs/arc42/full.adoc
+++ b/docs/src/docs/arc42/full.adoc
@@ -6,10 +6,10 @@ This work is licensed under the [Apache-2.0](https://www.apache.org/licenses/LIC
 
 * SPDX-License-Identifier: Apache-2.0
 * Licence Path: https://creativecommons.org/licenses/by/4.0/legalcode
-* Copyright (c) 2021,2022,2023 Contributors to the Eclipse Foundation
+* Copyright (c) 2021, 2022, 2023, 2024 Contributors to the Eclipse Foundation
 * Copyright (c) 2022, 2023 ZF Friedrichshafen AG
 * Copyright (c) 2022 ISTOS GmbH
-* Copyright (c) 2022, 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+* Copyright (c) 2022, 2023, 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
 * Copyright (c) 2022,2023 BOSCH AG
 
 * Source URL: https://github.com/eclipse-tractusx/traceability-foss

--- a/docs/src/docs/index.adoc
+++ b/docs/src/docs/index.adoc
@@ -7,11 +7,11 @@ This work is licensed under the [Apache-2.0](https://www.apache.org/licenses/LIC
 
 * SPDX-License-Identifier: Apache-2.0
 * Licence Path: https://creativecommons.org/licenses/by/4.0/legalcode
-* Copyright (c) 2021,2022,2023 Contributors to the Eclipse Foundation
+* Copyright (c) 2021, 2022, 2023, 2024 Contributors to the Eclipse Foundation
 * Copyright (c) 2022, 2023 ZF Friedrichshafen AG
 * Copyright (c) 2022 ISTOS GmbH
-* Copyright (c) 2022, 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
-* Copyright (c) 2022,2023 BOSCH AG
+* Copyright (c) 2022, 2023, 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+* Copyright (c) 2022, 2023 BOSCH AG
 
 * Source URL: https://github.com/eclipse-tractusx/traceability-foss
 

--- a/docs/src/docs/user/user-manual.adoc
+++ b/docs/src/docs/user/user-manual.adoc
@@ -6,10 +6,10 @@ This work is licensed under the [Apache-2.0](https://www.apache.org/licenses/LIC
 
 * SPDX-License-Identifier: Apache-2.0
 * Licence Path: https://creativecommons.org/licenses/by/4.0/legalcode
-* Copyright (c) 2021, 2022, 2023 Contributors to the Eclipse Foundation
+* Copyright (c) 2021, 2022, 2023, 2024 Contributors to the Eclipse Foundation
 * Copyright (c) 2022, 2023 ZF Friedrichshafen AG
 * Copyright (c) 2022 ISTOS GmbH
-* Copyright (c) 2022, 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+* Copyright (c) 2022, 2023, 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
 * Copyright (c) 2022, 2023 BOSCH AG
 * Source URL: https://github.com/eclipse-tractusx/traceability-foss
 


### PR DESCRIPTION
## Description
Update legal notice to year 2024 

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
