### PR TITLE
chore(charts): bump irs dependency to 7.2.1

### DIFF
--- a/COMPATIBILITY_MATRIX.md
+++ b/COMPATIBILITY_MATRIX.md
@@ -11,7 +11,7 @@
 | Dependency       | Name of Service              | Version              | Helm     | Comments                                            |
 |------------------|------------------------------|----------------------|----------|-----------------------------------------------------|
 | EDC              | edc-postgresql               | 15.4.0-debian-11-r45 | 12.12.10 | Enterprise Data Connector for PostgreSQL            |
-| IRS              | item-relationship-service    | 5.2.0                | 7.2.0    | Helm charts for Item Relationship Service           |
+| IRS              | item-relationship-service    | 5.2.0                | 7.2.1    | Helm charts for Item Relationship Service           |
 | EDC              | tractusx-connector           | 0.7.0                | 0.7.0    | Connector for Data Transfer and Registration        |
 | Discovery Finder | discovery service            | 0.2.5                | -        | Service for discovering and registering artifacts   |
 | Portal           | portal                       | 1.8.0                | -        | Web portal for interacting with Trace-X             |

--- a/charts/traceability-foss/CHANGELOG.md
+++ b/charts/traceability-foss/CHANGELOG.md
@@ -3,6 +3,9 @@
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+## [1.3.41] - 2024-07-10
+### No changes
+
 ## [1.3.40] - 2024-05-29
 ### No changes
 

--- a/charts/traceability-foss/Chart.yaml
+++ b/charts/traceability-foss/Chart.yaml
@@ -23,7 +23,7 @@ home: https://eclipse-tractusx.github.io/
 sources:
   - https://github.com/eclipse-tractusx/traceability-foss
 type: application
-version: 1.3.40
+version: 1.3.41
 appVersion: "12.0.0"
 dependencies:
   - name: frontend
@@ -42,7 +42,7 @@ dependencies:
     condition: pgadmin4.enabled
   - name: item-relationship-service
     repository: https://eclipse-tractusx.github.io/item-relationship-service
-    version: 7.2.0
+    version: 7.2.1
     condition: item-relationship-service.enabled
   - name: tractusx-connector
     repository: https://eclipse-tractusx.github.io/tractusx-edc

--- a/charts/traceability-foss/Chart.yaml
+++ b/charts/traceability-foss/Chart.yaml
@@ -28,10 +28,10 @@ appVersion: "12.0.0"
 dependencies:
   - name: frontend
     repository: "file://charts/frontend"
-    version: 1.3.40
+    version: 1.3.41
   - name: backend
     repository: "file://charts/backend"
-    version: 1.3.40
+    version: 1.3.41
   - name: postgresql
     repository: https://charts.bitnami.com/bitnami
     version: 12.12.10

--- a/charts/traceability-foss/charts/backend/Chart.yaml
+++ b/charts/traceability-foss/charts/backend/Chart.yaml
@@ -20,7 +20,7 @@ apiVersion: v2
 name: backend
 description: A Helm chart for Traceability backend application.
 type: application
-version: 1.3.40
+version: 1.3.41
 appVersion: "12.0.0"
 dependencies:
   - name: postgresql

--- a/charts/traceability-foss/charts/frontend/Chart.yaml
+++ b/charts/traceability-foss/charts/frontend/Chart.yaml
@@ -20,5 +20,5 @@ apiVersion: v2
 name: frontend
 description: A Helm chart for Traceability frontend application.
 type: application
-version: 1.3.40
+version: 1.3.41
 appVersion: "12.0.0"


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->
- new helm chart version 1.3.41
- bump IRS helm dependency to 7.2.1

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [ ] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [ ] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files


resolves eclipse-tractusx/traceability-foss#
