### PR TITLE
Chore/#1070 release checks 24.8 part4 #1070 Update documentation artefacts according to TRG 1 - Documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,8 @@ _**For better traceability add the corresponding GitHub issue number in each cha
 - #1190 update notification contracts on policy updates
 
 ### Changed
-- #1070 Correct semantic model in dev/READEME.md
+- #1070 Correct semantic model in dev/README.md
+- #1070 Update documentation artefacts according to TRG 1 - Documentation
 - #1070 Convert png to svg according to TRG 1.04 - Diagrams as code / Editable static files
 - #1173 Update IRS-Helm from 7.1.4 to 7.2.0 - updated Compatibility Matrix
 - #1082 fix duplicate key errors when synchronizing assets with IRS

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-# <ins>Contributing to Eclipse Tractus-X</ins>
+# Contributing to Eclipse Tractus-X
 
 Thanks for your interest in this project.
 
@@ -15,7 +15,7 @@ Thanks for your interest in this project.
 10. [Contact](#contact)
 
 
-## <ins>Project description</ins><a name="project_description"></a>
+## Project description
 
 The companies involved want to increase the automotive industry's
 competitiveness, improve efficiency through industry-specific cooperation and
@@ -30,20 +30,20 @@ Catena-X alliance focusing on parts traceability.
 - https://projects.eclipse.org/projects/automotive.tractusx
 - https://github.com/eclipse-tractusx/traceability-foss
 
-## <ins>Project licenses</ins><a name="project_licenses"></a>
+## Project licenses
 
 The Tractus-X project uses the following licenses:
 
-* Apache-2.0 for code
-* CC-BY-4.0 for non-code
+- [Apache-2.0 for code](LICENSE)
+- [CC-BY-4.0 for non-code](LICENSE_non-code)
 
-## <ins>Terms of Use</ins><a name="terms_of_use"></a>
+## Terms of Use
 
 This repository is subject to the Terms of Use of the Eclipse Foundation
 
-* https://www.eclipse.org/legal/termsofuse.php
+- https://www.eclipse.org/legal/termsofuse.php
 
-## <ins>Developer resources</ins><a name="developer_ressources"></a>
+## Developer resources
 
 Information regarding source code management, builds, coding standards, and
 more.
@@ -52,13 +52,13 @@ more.
 
 Getting started:
 
-* https://eclipse-tractusx.github.io/docs/developer
+- https://eclipse-tractusx.github.io/docs/developer
 
 The project maintains the source code repositories in the following GitHub organization:
 
 - https://github.com/eclipse-tractusx/
 
-## <ins>Eclipse Development Process</ins><a name="eclipse_commitment"></a>
+## Eclipse Development Process
 
 This Eclipse Foundation open project is governed by the Eclipse Foundation
 Development Process and operates under the terms of the Eclipse IP Policy.
@@ -66,7 +66,7 @@ Development Process and operates under the terms of the Eclipse IP Policy.
 - https://eclipse.org/projects/dev_process
 - https://www.eclipse.org/org/documents/Eclipse_IP_Policy.pdf
 
-## <ins>Eclipse Contributor Agreement</ins><a name="eclipse_agreement"></a>
+## Eclipse Contributor Agreement
 
 In order to be able to contribute to Eclipse Foundation projects you must
 electronically sign the Eclipse Contributor Agreement (ECA).
@@ -82,7 +82,7 @@ fulfills the DCO's requirement that you sign-off on your contributions.
 For more information, please see the Eclipse Committer Handbook:
 https://www.eclipse.org/projects/handbook/#resources-commit
 
-## <ins>General contribution to the project</ins> <a name="general"></a>
+## General contribution to the project
 
 ### Maintaining [CHANGELOG.md](CHANGELOG.md)
 All notable changes to this project will be documented in this file.
@@ -104,7 +104,7 @@ _**For better traceability add the corresponding GitHub issue number in each cha
 
 ### git-hooks
 Use git-hooks to ensure commit message consistency.
-Detailed pattern can be found here: [commit-msg](https://github.com/eclipse-tractusx/traceability-foss/blob/457cb3523e981ef6aed98355a7faf0ff29867c33/dev/commit-msg#L4)
+Detailed pattern can be found here: [commit-msg](dev/commit-msg#L4)
 
 #### How to use
 
@@ -128,7 +128,7 @@ docs(arc42):[#123] Added level 1 description for runtime view.
 chore(helm):[#113] Moving the values under the global key - increasing the version
 ````
 
-## Pull Request &  Reviews
+## Pull Request & Reviews
 
 The goal is that the maximal life cycle of a pull request: 1.5 days.
 
@@ -162,7 +162,7 @@ Only after the code is stable it can be merged to main.
   - MUST contain : Issue ID in the format #XXX
   - MUST contain: Subject of issue (Abbreviation of pbi summary without using spaces / use "-" to connect)
 
-<img src="https://raw.githubusercontent.com/eclipse-tractusx/traceability-foss/main/docs/images/github-flow-branching-model.svg" height="60%" width="60%"/>
+![github-flow-branching-model](docs/images/github-flow-branching-model.svg "github-flow-branching-model")
 
 ### Commit messages
 - The commit messages have to match a pattern in the form of:
@@ -173,21 +173,21 @@ Examples:
 - `feature(users): #DDD description`
 - `fix: #322 make X work again`
 
-The detailed pattern can be found here: [commit-msg](https://github.com/eclipse-tractusx/traceability-foss/blob/main/dev/commit-msg)
+The detailed pattern can be found here: [commit-msg](dev/commit-msg)
 
 #### How to use
 ```shell
 cp dev/commit-msg .git/hooks/commit-msg && chmod 500 .git/hooks/commit-msg
 ```
 
-## <ins>Contributing as a Consultant</ins><a name="consultant"></a>
+## Contributing as a Consultant
 
 ### Conceptual work and specification guidelines
 1. The prerequisite for a concept is always a github issue that defines the business value and the acceptance criteria that are to be implemented with the concept
 2. Copy and rename directory /docs/#000-concept-name-template /docs/#<DDD>-<target-name>
 3. Copy file /docs/Concept_TEMPLATE.md into new directory  /docs/#<DDD>-<target-name>
 
-## <ins>Contributing as a Developer (Developer Hints)</ins><a name="developer"></a>
+## Contributing as a Developer (Developer Hints)
 
 ### Coding styles
 
@@ -225,7 +225,7 @@ By following these steps, you can connect your remote SonarCloud instance with y
 ### Frontend coding guidelines
 These guidelines are defined to maintain homogeneous code quality and style. It can be adapted as the need arises.
 
-New and old developers should regularly review this [guide](https://github.com/eclipse-tractusx/traceability-foss/blob/main/frontend/GUIDELINES.md) to update it as new points emerge and to sync themselves with the latest changes.
+New and old developers should regularly review this [guide](frontend/GUIDELINES.md) to update it as new points emerge and to sync themselves with the latest changes.
 
 #### Angular Template Attribute Convention
 

--- a/DOCKER_NOTICE.md
+++ b/DOCKER_NOTICE.md
@@ -6,8 +6,8 @@ DockerHub Backend: https://hub.docker.com/r/tractusx/traceability-foss
 
 - GitHub: https://github.com/eclipse-tractusx/traceability-foss
 - Project home: https://projects.eclipse.org/projects/automotive.tractusx
-- Dockerfile Backend: https://github.com/eclipse-tractusx/traceability-foss/blob/main/Dockerfile
-- Project license: [Apache License, Version 2.0](https://github.com/eclipse-tractusx/traceability-foss/blob/main/LICENSE)
+- Dockerfile Backend: [Dockerfile](Dockerfile)
+- Project license: [Apache License, Version 2.0](LICENSE)
 
 **Used base image**
 - [eclipse-temurin:21-jre-alpine](https://github.com/adoptium/containers)

--- a/DOCKER_NOTICE.md
+++ b/DOCKER_NOTICE.md
@@ -1,8 +1,12 @@
 This application provides container images for demonstration purposes.
 
-Eclipse Tractus-X product(s) installed within the image:
+## Notice for Docker image
 
 DockerHub Backend: https://hub.docker.com/r/tractusx/traceability-foss
+
+Eclipse Tractus-X product(s) installed within the image:
+
+__Traceability-foss__
 
 - GitHub: https://github.com/eclipse-tractusx/traceability-foss
 - Project home: https://projects.eclipse.org/projects/automotive.tractusx

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,0 +1,9 @@
+# Installation Instructions
+
+## Installation Instructions Frontend
+
+- [Installation Instructions Frontend](frontend/INSTALL.md)
+
+## Installation Instructions Backend
+
+- [Installation Instructions Backend](tx-backend/INSTALL.md)

--- a/NOTICE.md
+++ b/NOTICE.md
@@ -20,8 +20,8 @@ source code repository logs.
 
 The Tractus-X project uses the following licenses:
 
-- Apache-2.0 for code
-- CC-BY-4.0 for non-code
+- [Apache-2.0 for code](LICENSE)
+- [CC-BY-4.0 for non-code](LICENSE_non-code)
 
 Apache-2.0:
 This program and the accompanying materials are made available under the terms of the Apache License, Version 2.0 which is available at https://www.apache.org/licenses/LICENSE-2.0.
@@ -42,7 +42,7 @@ in the GitHub organization https://github.com/eclipse-tractusx:
 
 This project leverages the following third party content.
 
-See DEPENDENCIES_BACKEND and DEPENDENCIES_FRONTEND file.
+See [DEPENDENCIES_BACKEND](DEPENDENCIES_BACKEND) and [DEPENDENCIES_FRONTEND](DEPENDENCIES_FRONTEND) file.
 
 ## Cryptography
 

--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ Please find [here](frontend/AUTHENTICATION.md) some important information about 
 
 ### Application Architecture & Patterns
 
-This [architecture](frontend/ARCHITECTURE.md) gives you a roadmap and best practices to follow when building an application
+This [Architecture](frontend/ARCHITECTURE.md) gives you a roadmap and best practices to follow when building an application
 so that you end up with a well-structured app.
 
 ### User Guide
@@ -149,7 +149,7 @@ so that you end up with a well-structured app.
 A detailed [explanation](docs/user/user-manual.adoc) of how to use the application.
 
 ### Frontend Testing Strategy
-See [TESTING](frontend/TESTING.md).
+See [Testing](frontend/TESTING.md).
 
 ## Backend Application
 
@@ -163,7 +163,7 @@ See [TESTING](frontend/TESTING.md).
 * see [Installation guide](tx-backend/INSTALL.md)
 
 ### Backend Testing Strategy
-See [TESTING](tx-backend/TESTING.md).
+See [Testing](tx-backend/TESTING.md).
 
 ## API Documentation
 The project follows [OpenAPI Specification](https://swagger.io/specification/) in order to document implemented REST Endpoints. The documentation can be found under [/openapi directory](https://github.com/eclipse-tractusx/traceability-foss/blob/main/tx-backend/openapi/traceability-foss-backend.json)

--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ See [Testing](frontend/TESTING.md).
 
 ### Backend Prerequisites
 
-* JDK 17
+* JDK 21
 * [Docker Engine](https://docs.docker.com/engine/)
 
 ### Backend Installation

--- a/frontend/DOCKER_NOTICE.md
+++ b/frontend/DOCKER_NOTICE.md
@@ -1,8 +1,12 @@
 This application provides container images for demonstration purposes.
 
-Eclipse Tractus-X product(s) installed within the image:
+## Notice for Docker image
 
 DockerHub Frontend: https://hub.docker.com/r/tractusx/traceability-foss-frontend
+
+Eclipse Tractus-X product(s) installed within the image:
+
+__Traceability-foss__
 
 - GitHub: https://github.com/eclipse-tractusx/traceability-foss
 - Project home: https://projects.eclipse.org/projects/automotive.tractusx

--- a/frontend/DOCKER_NOTICE.md
+++ b/frontend/DOCKER_NOTICE.md
@@ -6,8 +6,8 @@ DockerHub Frontend: https://hub.docker.com/r/tractusx/traceability-foss-frontend
 
 - GitHub: https://github.com/eclipse-tractusx/traceability-foss
 - Project home: https://projects.eclipse.org/projects/automotive.tractusx
-- Dockerfile Frontend: https://github.com/eclipse-tractusx/traceability-foss/blob/main/frontend/Dockerfile
-- Project license: [Apache License, Version 2.0](https://github.com/eclipse-tractusx/traceability-foss/blob/main/LICENSE)
+- Dockerfile Frontend: [Dockerfile](frontend/Dockerfile)
+- Project license: [Apache License, Version 2.0](LICENSE)
 
 **Used base image**
 

--- a/tx-backend/INSTALL.md
+++ b/tx-backend/INSTALL.md
@@ -9,9 +9,9 @@
 $ git clone https://github.com/eclipse-tractusx/traceability-foss.git
 $ cd traceability-foss
 ```
-Please note: Local deployment of the app is not supported. 
+Please note: Local deployment of the app is not supported.
 
-For deployment please find our helm chart github actions here: https://github.com/eclipse-tractusx/traceability-foss/actions/workflows/helm-upgrade.yaml and https://github.com/eclipse-tractusx/traceability-foss/actions/workflows/helm-test-backwards-compatability.yaml. Within this actions the full application is configured to start up. 
+For deployment please find our helm chart github actions here: [helm-upgrade.yaml](../.github/workflows/helm-upgrade.yaml) and [helm-test-backwards-compatability.yaml](../.github/workflows/helm-test-backwards-compatability.yaml). Within this actions the full application is configured to start up.
 
 ## OAuth2 configuration
 Product Traceability FOSS Backend relies on properly configured OAuth2 instance. In order to work, it must be configured with proper realm, clients and roles.
@@ -22,9 +22,10 @@ Users should have one of the following roles assigned:
 
 ## Helm secrets configuration
 Product Traceability FOSS Backend ships with helm charts and utilize [helm dependency](https://helm.sh/docs/helm/helm_dependency/) functionality for 3rd party components.
-In order to deploy the service following secrets needs to be provided for specific environment [see project helm environment specifc files](https://github.com/eclipse-tractusx/traceability-foss/blob/main/charts/traceability-foss-backend):
 
-### OAuth2
+### OAuth2 Properties
+In order to deploy the service following secrets needs to be provided for specific environment [see project helm environment specifc files](../charts/traceability-foss/charts/backend/values.yaml):
+
 * `oauth2.clientId` - OAuth2 client registration id credentials
 * `oauth2.clientSecret` - OAuth2 client registration secret credentials
 
@@ -46,7 +47,7 @@ spring:
     flyway:
         clean-on-validation-error: false
 ```
-Database scripts are executed with Flyway. Put the scripts at [migration](https://github.com/eclipse-tractusx/traceability-foss/blob/main/backend/src/main/resources/db/migration)
+Database scripts are executed with Flyway. Put the scripts at [migration](src/main/resources/db/migration)
 
 * `postgresql.secret.initUserDbSql` - database initialization script, contains username and password for databases used by the service.
 Please note that the final script should be encoded using Base64 encoding and then added to a secret. Sample command:
@@ -61,7 +62,6 @@ echo -n 'CREATE ROLE trace WITH LOGIN PASSWORD 'yourPassword';\nCREATE DATABASE 
 
 ## Helm installation
 Add the Trace-X Backend Helm repository:
-
 
 ```sh
 $ helm repo add traceability-foss-backend https://eclipse-tractusx.github.io/traceability-foss-backend

--- a/tx-backend/INSTALL.md
+++ b/tx-backend/INSTALL.md
@@ -1,7 +1,5 @@
-<div style="display: flex; align-items: center;justify-content: center;align-content: center;">
-   <img src="https://raw.githubusercontent.com/eclipse-tractusx/traceability-foss/main/docs/trace-x-logo.svg" alt="Product Traceability FOSS Backend Installation Guide" style="width:200px;"/>
-   <h1 style="margin: 10px 0 0 10px">Product Traceability FOSS Backend Installation guide</h1>
-</div>
+![Trace-X](../docs/trace-x-logo.svg)
+# Product Traceability FOSS Backend Installation guide
 
 ## Clone the source locally:
 
@@ -24,7 +22,7 @@ Users should have one of the following roles assigned:
 Product Traceability FOSS Backend ships with helm charts and utilize [helm dependency](https://helm.sh/docs/helm/helm_dependency/) functionality for 3rd party components.
 
 ### OAuth2 Properties
-In order to deploy the service following secrets needs to be provided for specific environment [see project helm environment specifc files](../charts/traceability-foss/charts/backend/values.yaml):
+In order to deploy the service following secrets needs to be provided for specific environment [project helm environment specific files](../charts/traceability-foss/charts/backend/values.yaml):
 
 * `oauth2.clientId` - OAuth2 client registration id credentials
 * `oauth2.clientSecret` - OAuth2 client registration secret credentials
@@ -72,7 +70,7 @@ Then install the Helm chart into your cluster:
 $ helm install -f your-values.yaml traceability-foss backend/traceability-foss-backend
 ```
 
-== Deployment using ArgoCD
+## Deployment using ArgoCD
 
 Create a new Helm chart and use Trace-X as a dependency.
 


### PR DESCRIPTION
## Description
-#1070 Update documentation artefacts according to TRG 1 - Documentation

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files


resolves eclipse-tractusx/traceability-foss#1070
