### PR TITLE
chore(docker): define uid and gid directly in user, instead of variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ _**For better traceability add the corresponding GitHub issue number in each cha
 - #1222 Removed image publishing to GHCR
 - #1222 Adjust backend baseimage in Dockerfile to major version eclipse-temurin:21-jre-alpine
 - #XXX update springboot to 3.2.8 from 3.2.5
+- #XXX define uid and gid of backend Dockerfile directly in user, instead of variables
 
 ## [13.0.0 - 19.07.2024]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -41,14 +41,11 @@ RUN --mount=type=cache,target=/root/.m2 mvn -B clean package -pl :$BUILD_TARGET 
 # Copy the jar and build image
 FROM eclipse-temurin:21-jre-alpine AS traceability-app
 
-ARG UID=10000
-ARG GID=1000
-
 WORKDIR /app
 
 COPY --chmod=755 --from=maven /build/tx-backend/target/traceability-app-*-exec.jar app.jar
 
-USER ${UID}:${GID}
+USER 10000:1000
 
 ENTRYPOINT ["java", "-jar", "app.jar"]
 


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->
Fixes failing workflow https://github.com/eclipse-tractusx/traceability-foss/actions/workflows/quality-checks.yaml
https://github.com/eclipse-tractusx/traceability-foss/actions/runs/10072265123

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files


resolves eclipse-tractusx/traceability-foss#
