### PR TITLE
feature: split sonar action from pr action

### DIFF
--- a/.github/workflows/pull-request_backend.yml
+++ b/.github/workflows/pull-request_backend.yml
@@ -56,8 +56,7 @@ jobs:
         run: |
           echo ${{steps.pom-version.outputs.pom_changed}}
 
-
-  Test-and-Sonar:
+  Test:
     permissions:
       checks: write
       pull-requests: write
@@ -87,6 +86,21 @@ jobs:
           files: "**/surefire-reports/TEST-*.xml"
           check_name: "Unit Test Results"
 
+  Sonar:
+    needs: Test
+    permissions:
+      checks: write
+      pull-requests: write
+    runs-on: ubuntu-latest
+    if: success()
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          java-version: '${{ env.JAVA_VERSION }}'
+          distribution: 'temurin'
+          cache: 'maven'
+
       - name: Clean working directories
         run: |
           rm -rf .scannerwork
@@ -99,6 +113,9 @@ jobs:
           key: ${{ runner.os }}-sonar
           restore-keys: ${{ runner.os }}-sonar
 
+      - name: Compile
+        run: mvn -pl tx-models,tx-backend,tx-coverage -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn -B compile
+
       - name: Verify Sonar Scan
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
@@ -108,7 +125,7 @@ jobs:
         run: mvn -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn --batch-mode sonar:sonar -Dsonar.coverage.jacoco.xmlReportPaths=${{ github.workspace }}/tx-coverage/target/site/jacoco-aggregate/jacoco.xml -Dsonar.projectKey=${{ vars.SONAR_PROJECT_KEY_BACKEND }} -Dsonar.organization=${{ vars.SONAR_ORGANIZATION }}
 
   Publish-docker-image:
-   # needs: [ "Test-and-Sonar" ]
+    # needs: [ "Test-and-Sonar" ]
     runs-on: ubuntu-latest
     defaults:
       run:


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->
This PR refactors the pull-request_backend.yml to split the Sonar step from the Test step. This avoids the test fail even though Sonar was not available.

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files


resolves traceability-foss#
