### PR TITLE
fix: [TRACEX-528] remove authTime to support keycloak 25

### DIFF
--- a/frontend/src/app/modules/core/auth/auth.service.ts
+++ b/frontend/src/app/modules/core/auth/auth.service.ts
@@ -29,7 +29,6 @@ export interface UserData {
   surname: string;
   email: string;
   roles: string[];
-  auth_time: string;
   bpn: string;
 }
 
@@ -51,14 +50,12 @@ export class AuthService {
       family_name: surname = '',
       email = '',
       resource_access = {},
-      auth_time: key_auth_time,
       bpn = '',
     } = this.keycloakService.getKeycloakInstance().tokenParsed;
 
-    const auth_time = key_auth_time.toString();
     const roles = resource_access[environment.clientId]?.roles ?? [];
 
-    return { username, firstname, surname, email, auth_time, roles, bpn };
+    return { username, firstname, surname, email, roles, bpn };
   }
 
   public logOut(): void {


### PR DESCRIPTION
## Description

<!-- Provide a clear and concise description of the changes introduced by this pull request. Explain the problem it 
solves or the feature it adds. -->
There was a bug, when keycloak did not provide authTime which results in a null pointer on our side. 

## Motivation

<!-- Why are these changes necessary? What problem does it solve? -->
Be compatible to latest keycloak (25)

## Changes

<!--List the key changes made in this pull request. Use bullet points for clarity. -->

- Removal of authTime field to prevent null pointers

## Issue

Refs: [266 (portal)](https://github.com/eclipse-tractusx/portal-iam/issues/266)