### PR TITLE
fix: eclipse-tractusx/sig-release#1327 repair filter in broken cucumber tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ _**For better traceability add the corresponding GitHub issue number in each cha
 - repair unit test pipeline and revert breaking dependency changes eclipse-tractusx/traceability-foss/issues#1439
 - change dummy test controller to post requests to resolve CSRF alert eclipse-tractusx/traceability-foss/issues#1439
 - repair flaky integration tests eclipse-tractusx/traceability-foss/issues#1439
+- fix notification filter for automated tests eclipse-tractusx/sig-release#1327
 
 ### Removed
 - Remove unused vulnerable dependency commons-fileupload eclipse-tractusx/traceability-foss/issues#1439

--- a/tx-cucumber-tests/src/test/java/org/eclipse/tractusx/traceability/test/tooling/rest/RestProvider.java
+++ b/tx-cucumber-tests/src/test/java/org/eclipse/tractusx/traceability/test/tooling/rest/RestProvider.java
@@ -246,21 +246,28 @@ public class RestProvider {
     }
 
     public List<NotificationResponse> getReceivedNotifications() {
-
         return given().spec(getRequestSpecification())
                 .contentType(ContentType.JSON)
                 .when()
                 .body("""
                         {
-                            "pageAble": {
-                                "size": 1000\s
-                            },
-                            "searchCriteria": {
-                                "filter": [
-                                    "channel,EQUAL,RECEIVER,AND"
-                                ]
+                          "page": 0,
+                          "size": 1000,
+                          "sort": ["created,desc"],
+                          "notificationFilter": {
+                            "channel": {
+                              "value": [
+                                {
+                                  "value": "RECEIVER",
+                                  "strategy": "OR"
+
+                                }
+                              ],
+                              "operator": "EQUAL"
                             }
-                        }""")
+                          }
+                        }
+                        """)
                 .post("/api/notifications/filter")
                 .then()
                 .statusCode(HttpStatus.SC_OK)


### PR DESCRIPTION

<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->
Repaired the changed notification filter to fix e2e tests. 

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->
eclipse-tractusx/sig-release#1327

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
