### PR TITLE
fix: eclipse-tractusx/sig-release#1327 repair filter in broken cucumber tests

### DIFF
--- a/tx-cucumber-tests/src/test/java/org/eclipse/tractusx/traceability/test/tooling/rest/RestProvider.java
+++ b/tx-cucumber-tests/src/test/java/org/eclipse/tractusx/traceability/test/tooling/rest/RestProvider.java
@@ -253,7 +253,7 @@ public class RestProvider {
                         {
                           "page": 0,
                           "size": 1000,
-                          "sort": ["created,desc"],
+                          "sort": ["createdDate,desc"],
                           "notificationFilter": {
                             "channel": {
                               "value": [


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->
Repaired the changed notification filter to fix e2e tests. 

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->
eclipse-tractusx/sig-release#1327

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
