### PR TITLE
fix(values): #1439 edc values to force dcp v08

### DIFF
--- a/charts/traceability-foss/values-int-a-catena-ev.yaml
+++ b/charts/traceability-foss/values-int-a-catena-ev.yaml
@@ -488,6 +488,15 @@ tractusx-connector:
         cpu: 15m
         memory: 1.5Gi
 
+    # workaround for 0.10.0-rc2
+    catalog:
+      cache:
+        execution:
+          enabled: false
+    dcp:
+      v08:
+        forced: true
+
   dataplane:
     token:
       signer:

--- a/charts/traceability-foss/values-int-b-catena-ev.yaml
+++ b/charts/traceability-foss/values-int-b-catena-ev.yaml
@@ -486,6 +486,16 @@ tractusx-connector:
         cpu: 15m
         memory: 1.5Gi
 
+    # workaround for 0.10.0-rc2
+    catalog:
+      cache:
+        execution:
+          enabled: false
+    dcp:
+      v08:
+        forced: true
+
+
   dataplane:
     token:
       signer:


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->
The new release candidate of the connector needs some further adjustments:
https://matrix.to/#/!fgTCQAaMutepjWCuLl:matrix.eclipse.org/$XTO11TpFN2B8buHWk36xzy-k-owwB7Wy56h44wZy1UU?via=matrix.eclipse.org&via=matrix.org
https://github.com/eclipse-tractusx/tractusx-edc/issues/1965
We will force dcp version 8 to avoid this bug. (Workaround solution)

Is part of the deployment for 25.06 release: #1439 

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
