### PR TITLE
chore: use fixed SHAs for actions/checkout

### DIFF
--- a/.github/workflows/argo.yml
+++ b/.github/workflows/argo.yml
@@ -1,0 +1,427 @@
+#    Copyright (c) 2023 Contributors to the Eclipse Foundation
+#
+#    See the NOTICE file(s) distributed with this work for additional
+#    information regarding copyright ownership.
+#
+#    This program and the accompanying materials are made available under the
+#    terms of the Apache License, Version 2.0 which is available at
+#    https://www.apache.org/licenses/LICENSE-2.0.
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+#
+#  SPDX-License-Identifier: Apache-2.0
+
+# For most projects, this workflow file will not need changing; you simply need
+# to commit it to your repository.
+#
+# You may wish to alter this file to override the set of languages analyzed,
+# or to provide custom queries or build logic.
+#
+name: Reset Argo ENV and Testdata import
+
+on:
+  workflow_dispatch:
+    inputs:
+      environment:
+        type: choice
+        description: Which Environment
+        required: true
+        options:
+        - Dev/Test
+        - E2E-A/E2E-B
+        - int-a/int-b
+        - association int-a/int-b
+
+      testdata_version:
+        description: Which Testdata Version CX_Testdata_MessagingTest_v<X.X.X>.json e.g., 0.0.14"
+        required: true
+      argo_token:
+        description: Argo Token
+        required: true
+      hard_refresh:
+        type: choice
+        description: Do you want a Hard Refresh? (+5min execution time)
+        required: true
+        options:
+        - Yes
+        - No
+      testdata_upload:
+        type: choice
+        description: Do you want a testdata upload?
+        required: true
+        options:
+        - Yes
+        - No
+
+env:
+    ARGO_TEST_REGISTRY: "https://argo.dev.demo.catena-x.net/api/v1/applications/tracex-dt-registry-test"
+    ARGO_TEST_EDC_PROVIDER: "https://argo.dev.demo.catena-x.net/api/v1/applications/tracex-test-edc-provider"
+    ARGO_TEST_TRACE_X_INSTANCE: "https://argo.dev.demo.catena-x.net/api/v1/applications/traceability-foss-test"
+    ARGO_TEST_SUBMODELSERVER: "https://argo.dev.demo.catena-x.net/api/v1/applications/tracex-test-submodelserver"
+    ARGO_TEST_RegistryReload: "https://traceability-test.dev.demo.catena-x.net/api/registry/reload"
+
+    ARGO_DEV_REGISTRY: "https://argo.dev.demo.catena-x.net/api/v1/applications/tracex-dt-registry-dev"
+    ARGO_DEV_EDC_PROVIDER: "https://argo.dev.demo.catena-x.net/api/v1/applications/tracex-edc-provider"
+    ARGO_DEV_TRACE_X_INSTANCE: "https://argo.dev.demo.catena-x.net/api/v1/applications/traceability-foss-dev"
+    ARGO_DEV_SUBMODELSERVER: "https://argo.dev.demo.catena-x.net/api/v1/applications/tracex-dev-submodelserver"
+    ARGO_DEV_RegistryReload: "https://traceability.dev.demo.catena-x.net/api/registry/reload"
+
+    ARGO_E2E_A_REGISTRY: "https://argo.dev.demo.catena-x.net/api/v1/applications/tracex-dt-registry-e2e-a"
+    ARGO_E2E_A_EDC_PROVIDER: "https://argo.dev.demo.catena-x.net/api/v1/applications/tracex-edc-provider-e2e-a"
+    ARGO_E2E_A_TRACE_X_INSTANCE: "https://argo.dev.demo.catena-x.net/api/v1/applications/traceability-foss-e2e-a"
+    ARGO_E2E_A_SUBMODELSERVER: "https://argo.dev.demo.catena-x.net/api/v1/applications/tracex-e2e-a-submodelserver"
+    ARGO_E2E_A_RegistryReload: "https://traceability-e2e-a.dev.demo.catena-x.net/api/registry/reload"
+
+    ARGO_E2E_B_REGISTRY: "https://argo.dev.demo.catena-x.net/api/v1/applications/tracex-dt-registry-e2e-b"
+    ARGO_E2E_B_EDC_PROVIDER: "https://argo.dev.demo.catena-x.net/api/v1/applications/tracex-edc-provider-e2e-b"
+    ARGO_E2E_B_TRACE_X_INSTANCE: "https://argo.dev.demo.catena-x.net/api/v1/applications/traceability-foss-e2e-b"
+    ARGO_E2E_B_SUBMODELSERVER: "https://argo.dev.demo.catena-x.net/api/v1/applications/tracex-e2e-b-submodelserver"
+    ARGO_E2E_B_RegistryReload: "https://traceability-e2e-b.dev.demo.catena-x.net/api/registry/reload"
+
+    ARGO_INT_A_REGISTRY: "https://argo.int.demo.catena-x.net/api/v1/applications/tx-registry-int-a"
+    ARGO_INT_A_EDC_PROVIDER: "https://argo.int.demo.catena-x.net/api/v1/applications/tx-edc-provider-int-a"
+    ARGO_INT_A_TRACE_X_INSTANCE: "https://argo.int.demo.catena-x.net/api/v1/applications/traceability-foss-int-a"
+    ARGO_INT_A_SUBMODELSERVER: "https://argo.int.demo.catena-x.net/api/v1/applications/tracex-int-a-submodelserver"
+    ARGO_INT_A_RegistryReload: "https://traceability-int-a.int.demo.catena-x.net/api/registry/reload"
+
+    ARGO_INT_B_REGISTRY: "https://argo.int.demo.catena-x.net/api/v1/applications/tx-registry-int-b"
+    ARGO_INT_B_EDC_PROVIDER: "https://argo.int.demo.catena-x.net/api/v1/applications/tx-edc-provider-int-b"
+    ARGO_INT_B_TRACE_X_INSTANCE: "https://argo.int.demo.catena-x.net/api/v1/applications/traceability-foss-int-b"
+    ARGO_INT_B_SUBMODELSERVER: "https://argo.int.demo.catena-x.net/api/v1/applications/tracex-int-b-submodelserver"
+    ARGO_INT_B_RegistryReload: "https://traceability-int-b.int.demo.catena-x.net/api/registry/reload"
+
+    ARGO_ASSOCIATION_INT_A_REGISTRY: "https://argocd.int.catena-x.net/api/v1/applications/tracex-registry-int-a"
+    ARGO_ASSOCIATION_INT_A_EDC_PROVIDER: "https://argocd.int.catena-x.net/api/v1/applications/tx-edc-provider-int-a"
+    ARGO_ASSOCIATION_INT_A_TRACE_X_INSTANCE: "https://argocd.int.catena-x.net/api/v1/applications/traceability-foss-int-a"
+    ARGO_ASSOCIATION_INT_A_SUBMODELSERVER: "https://argocd.int.catena-x.net/api/v1/applications/trace-x-int-a-submodelserver-submodelservers"
+
+    ARGO_ASSOCIATION_INT_B_REGISTRY: "https://argocd.int.catena-x.net/api/v1/applications/tracex-registry-int-b"
+    ARGO_ASSOCIATION_INT_B_EDC_PROVIDER: "https://argocd.int.catena-x.net/api/v1/applications/tx-edc-provider-int-b"
+    ARGO_ASSOCIATION_INT_B_TRACE_X_INSTANCE: "https://argocd.int.catena-x.net/api/v1/applications/traceability-foss-int-b"
+    ARGO_ASSOCIATION_INT_B_SUBMODELSERVER: "https://argocd.int.catena-x.net/api/v1/applications/trace-x-int-b-submodelserver-submodelservers"
+
+
+
+
+
+
+jobs:
+  test_input:
+   runs-on: ubuntu-latest
+   steps:
+
+      - name: Checkout-Repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      - name: mask token
+        run: |
+          ARGO_TOKEN=$(jq -r '.inputs.argo_token' $GITHUB_EVENT_PATH)
+          echo ::add-mask::$ARGO_TOKEN
+          echo ARGO_TOKEN=$ARGO_TOKEN >> $GITHUB_ENV
+
+      - name: Check Testdata Version Format
+        run: |
+         if [[ ! "${{ github.event.inputs.testdata_version }}" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9]+)?$ ]]; then
+          echo "Invalid Testdata Version format. Please use X.X.X or X.X.X-suffix, e.g., 1.1.12"
+          exit 1
+         fi
+
+      - name: Check Argo Token
+        run: |
+
+           source ./.github/argo/argo_config.sh
+
+           if [ "${{ github.event.inputs.environment }}" == "Dev/Test" ]; then
+              resources="${DEV_TEST_RESOURCES[2]}"
+            elif [ "${{ github.event.inputs.environment }}" == "E2E-A/E2E-B" ]; then
+              resources="${E2E_RESOURCES[2]}"
+            elif [ "${{ github.event.inputs.environment }}" == "int-a/int-b" ]; then
+              resources="${INT_RESOURCES[2]}"
+            elif [ "${{ github.event.inputs.environment }}" == "association int-a/int-b" ]; then
+             resources="${ASSOCIATION_INT_RESOURCES[2]}"
+            fi
+
+           data=$(curl -X GET -H "Authorization: Bearer ${{ env.ARGO_TOKEN }}" "$resources")
+           status_app=$(echo "$data" | jq -r '.status.sync.status')
+           if [ $status_app != null ]; then
+             echo "Argo Token is valid."
+           else
+            echo "Argo Token is invalid."
+            exit 1
+           fi
+
+
+  print_environment:
+   needs: test_input
+   runs-on: ubuntu-latest
+   steps:
+      - name: ${{ github.event.inputs.environment }}
+        run: |
+          echo "### inputs" >> $GITHUB_STEP_SUMMARY
+          echo "- environment: ${{ github.event.inputs.environment }}" >> $GITHUB_STEP_SUMMARY
+          echo "- test data version: ${{ github.event.inputs.testdata_version }}" >> $GITHUB_STEP_SUMMARY
+          echo "- do hard refresh: ${{ github.event.inputs.hard_refresh }}" >> $GITHUB_STEP_SUMMARY
+          echo "- upload test data: ${{ github.event.inputs.testdata_upload }}" >> $GITHUB_STEP_SUMMARY
+
+  hard_refresh_environment:
+   needs: print_environment
+   runs-on: ubuntu-latest
+   steps:
+
+      - name: Checkout-Repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      - name: mask token
+        run: |
+          ARGO_TOKEN=$(jq -r '.inputs.argo_token' $GITHUB_EVENT_PATH)
+          echo ::add-mask::$ARGO_TOKEN
+          echo ARGO_TOKEN=$ARGO_TOKEN >> $GITHUB_ENV
+
+      - name: Hard refresh environment ${{ github.event.inputs.environment }}
+        run: |
+         source ./.github/argo/argo_config.sh
+
+         if [ "${{ github.event.inputs.hard_refresh }}" == "true" ]; then
+           if [ "${{ github.event.inputs.environment }}" == "Dev/Test" ]; then
+              resources=("${DEV_TEST_RESOURCES[@]}")
+           elif [ "${{ github.event.inputs.environment }}" == "E2E-A/E2E-B" ]; then
+              resources=("${E2E_RESOURCES[@]}")
+           elif [ "${{ github.event.inputs.environment }}" == "int-a/int-b" ]; then
+              resources=("${INT_RESOURCES[@]}")
+           elif [ "${{ github.event.inputs.environment }}" == "association int-a/int-b" ]; then
+               resources=("${ASSOCIATION_INT_RESOURCES[@]}")
+           fi
+
+           for resource in "${resources[@]}"; do
+             curl -X GET -H "Authorization: Bearer ${{ env.ARGO_TOKEN }}" "$resource?refresh=hard&appNamespace=argocd"
+           done
+           sleep 40
+         elif [ "${{ github.event.inputs.hard_refresh }}" == "false" ]; then
+          echo "Hard refresh skipped"
+         fi
+
+  delete_environment:
+    needs: hard_refresh_environment
+    runs-on: ubuntu-latest
+    steps:
+
+      - name: Checkout-Repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      - name: mask token
+        run: |
+          ARGO_TOKEN=$(jq -r '.inputs.argo_token' $GITHUB_EVENT_PATH)
+          echo ::add-mask::$ARGO_TOKEN
+          echo ARGO_TOKEN=$ARGO_TOKEN >> $GITHUB_ENV
+
+      - name: Delete Argo Environment
+        run: |
+         source ./.github/argo/argo_config.sh
+
+         if [ "${{ github.event.inputs.environment }}" == "Dev/Test" ]; then
+            resources=("${DELETE_DEV_TEST_RESOURCES[@]}")
+         elif [ "${{ github.event.inputs.environment }}" == "E2E-A/E2E-B" ]; then
+            resources=("${DELETE_E2E_RESOURCES[@]}")
+         elif [ "${{ github.event.inputs.environment }}" == "int-a/int-b" ]; then
+            resources=("${DELETE_INT_RESOURCES[@]}")
+         elif [ "${{ github.event.inputs.environment }}" == "association int-a/int-b" ]; then
+            resources=("${DELETE_ASSOCIATION_INT_RESOURCES[@]}")
+         fi
+
+         for resource in "${resources[@]}"; do
+           curl -X DELETE -H "Authorization: Bearer ${{ env.ARGO_TOKEN }}" -H "Content-Type: application/json" "$resource"
+           sleep 2
+         done
+         sleep 10
+
+  change_target_revision:
+      needs: delete_environment
+      runs-on: ubuntu-latest
+      steps:
+
+        - name: mask token
+          run: |
+            ARGO_TOKEN=$(jq -r '.inputs.argo_token' $GITHUB_EVENT_PATH)
+            echo ::add-mask::$ARGO_TOKEN
+            echo ARGO_TOKEN=$ARGO_TOKEN >> $GITHUB_ENV
+
+        - name: Change TargetRevison
+          run: |
+            new_target_revision=${{ github.ref_name }}
+
+            if [ "${{ github.event.inputs.environment }}" == "Dev/Test" ]; then
+
+              json_data1=$(curl -X GET -H "Authorization: Bearer ${{ env.ARGO_TOKEN }}" "$ARGO_TEST_TRACE_X_INSTANCE")
+              old_TargetRevision1=$(echo "$json_data1" | jq -r '.spec.source.targetRevision')
+              json_data2=$(curl -X GET -H "Authorization: Bearer ${{ env.ARGO_TOKEN }}" "$ARGO_DEV_TRACE_X_INSTANCE")
+              old_TargetRevision2=$(echo "$json_data2" | jq -r '.spec.source.targetRevision')
+
+              if [ "$old_TargetRevision1" != "$new_target_revision" ]; then
+                updated_json1=$(echo "$json_data1" | jq ".spec.source.targetRevision = \"$new_target_revision\"")
+                curl -X PUT -H "Content-Type: application/json" -H "Authorization: Bearer ${{ env.ARGO_TOKEN }}" -d "$updated_json1" "$ARGO_TEST_TRACE_X_INSTANCE"
+                echo "Target Revision for Test overwritten"
+              fi
+
+              if [ "$old_TargetRevision2" != "$new_target_revision" ]; then
+                updated_json2=$(echo "$json_data2" | jq ".spec.source.targetRevision = \"$new_target_revision\"")
+                curl -X PUT -H "Content-Type: application/json" -H "Authorization: Bearer ${{ env.ARGO_TOKEN }}" -d "$updated_json2" "$ARGO_DEV_TRACE_X_INSTANCE"
+                echo "Target Revision for Dev overwritten"
+              fi
+
+
+            elif [ "${{ github.event.inputs.environment }}" == "E2E-A/E2E-B" ]; then
+
+              json_data1=$(curl -X GET -H "Authorization: Bearer ${{ env.ARGO_TOKEN }}" "$ARGO_E2E_A_TRACE_X_INSTANCE")
+              old_TargetRevision1=$(echo "$json_data1" | jq -r '.spec.source.targetRevision')
+              json_data2=$(curl -X GET -H "Authorization: Bearer ${{ env.ARGO_TOKEN }}" "$ARGO_E2E_B_TRACE_X_INSTANCE")
+              old_TargetRevision2=$(echo "$json_data2" | jq -r '.spec.source.targetRevision')
+
+              if [ "$old_TargetRevision1" != "$new_target_revision" ]; then
+                updated_json1=$(echo "$json_data1" | jq ".spec.source.targetRevision = \"$new_target_revision\"")
+                curl -X PUT -H "Content-Type: application/json" -H "Authorization: Bearer ${{ env.ARGO_TOKEN }}" -d "$updated_json1" "$ARGO_E2E_A_TRACE_X_INSTANCE"
+                echo "Target Revision for e2e-a overwritten"
+              fi
+
+              if [ "$old_TargetRevision2" != "$new_target_revision" ]; then
+                updated_json2=$(echo "$json_data2" | jq ".spec.source.targetRevision = \"$new_target_revision\"")
+                curl -X PUT -H "Content-Type: application/json" -H "Authorization: Bearer ${{ env.ARGO_TOKEN }}" -d "$updated_json2" "$ARGO_E2E_B_TRACE_X_INSTANCE"
+                echo "Target Revision for e2e-b overwritten"
+              fi
+
+            fi
+
+  sync_environment:
+      needs: change_target_revision
+      runs-on: ubuntu-latest
+      steps:
+
+        - name: Checkout-Repository
+          uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+        - name: mask token
+          run: |
+            ARGO_TOKEN=$(jq -r '.inputs.argo_token' $GITHUB_EVENT_PATH)
+            echo ::add-mask::$ARGO_TOKEN
+            echo ARGO_TOKEN=$ARGO_TOKEN >> $GITHUB_ENV
+
+        - name: Sync Argo Environment
+          run: |
+            source ./.github/argo/argo_config.sh
+
+            if [ "${{ github.event.inputs.environment }}" == "Dev/Test" ]; then
+              resources=("${SYNC_DEV_TEST_RESOURCES[@]}")
+            elif [ "${{ github.event.inputs.environment }}" == "E2E-A/E2E-B" ]; then
+             resources=("${SYNC_E2E_RESOURCES[@]}")
+            elif [ "${{ github.event.inputs.environment }}" == "int-a/int-b" ]; then
+             resources=("${SYNC_INT_RESOURCES[@]}")
+            elif [ "${{ github.event.inputs.environment }}" == "association int-a/int-b" ]; then
+             resources=("${SYNC_ASSOCIATION_INT_RESOURCES[@]}")
+            fi
+
+              for resource in "${resources[@]}"; do
+              curl -X POST -H "Authorization: Bearer ${{ env.ARGO_TOKEN }}"  -H "Content-Type: application/json" "$resource"
+            done
+            sleep 20
+
+
+  test_state:
+      needs: sync_environment
+      runs-on: ubuntu-latest
+      timeout-minutes: 15
+      steps:
+
+        - name: Checkout code
+          uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+        - name: mask token
+          run: |
+            ARGO_TOKEN=$(jq -r '.inputs.argo_token' $GITHUB_EVENT_PATH)
+            echo ::add-mask::$ARGO_TOKEN
+            echo ARGO_TOKEN=$ARGO_TOKEN >> $GITHUB_ENV
+
+        - name: test apps state
+          run: |
+           source ./.github/argo/argo_config.sh
+           if [ "${{ github.event.inputs.environment }}" == "Dev/Test" ]; then
+              resources=("${DEV_TEST_RESOURCES[@]}")
+            elif [ "${{ github.event.inputs.environment }}" == "E2E-A/E2E-B" ]; then
+              resources=("${E2E_RESOURCES[@]}")
+            elif [ "${{ github.event.inputs.environment }}" == "int-a/int-b" ]; then
+              resources=("${INT_RESOURCES[@]}")
+             elif [ "${{ github.event.inputs.environment }}" == "association int-a/int-b" ]; then
+               resources=("${ASSOCIATION_INT_RESOURCES[@]}")
+            fi
+
+              for resource in "${resources[@]}"; do
+                while true; do
+                   json_data=$(curl -X GET -H "Authorization: Bearer ${{ env.ARGO_TOKEN }}" "$resource")
+                   status=$(echo "$json_data" | jq -r '.status.sync.status')
+                   health=$(echo "$json_data" | jq -r '.status.health.status')
+                   operationState=$(echo "$json_data" | jq -r '.status.operationState.phase')
+                   if [ "$status" == "Synced" ] && [ "$health" == "Healthy" ] && [ "$operationState" == "Succeeded" ]; then
+                    echo "ready"
+                    break
+                  elif [ "$operationState" == "Failed" ] || ([ "$status" == "OutOfSync" ] && [ "$operationState" == "Failed" ]) || ([ "$status" == "OutOfSync" ] && [ "$operationState" == "Succeeded" ]); then
+                    echo "Another sync"
+                    curl -X POST -H "Authorization: Bearer ${{ env.ARGO_TOKEN }}" -H "Content-Type: application/json" "$resource/sync"
+                    sleep 10
+                  elif [ "$status" == "OutOfSync" ] && [ "$operationState" == "Running" ]; then
+                    echo "First terminate sync then start another sync"
+                    curl -X DELETE -H "Authorization: Bearer ${{ env.ARGO_TOKEN }}" -H "Content-Type: application/json" "$resource/operation?appNamespace=argocd"
+                    sleep 10
+                    curl -X POST -H "Authorization: Bearer ${{ env.ARGO_TOKEN }}" -H "Content-Type: application/json" "$resource/sync"
+                    sleep 10
+                  else
+                    echo "Wait"
+                    sleep 10
+                  fi
+                done
+              done
+              sleep 120
+
+  upload_testdata:
+    needs: test_state
+    runs-on: ubuntu-latest
+    steps:
+
+     - name: Checkout code
+       uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+     - name: Set up Python
+       uses: actions/setup-python@v5
+       with:
+        python-version: '3.11'
+
+     - name: Upload testdata
+       run: |
+        python -m pip install requests
+        curl -o transform-and-upload.py https://raw.githubusercontent.com/eclipse-tractusx/item-relationship-service/main/local/testing/testdata/transform-and-upload.py
+        if [ "${{ github.event.inputs.testdata_upload }}" == "true" ]; then
+          if [ "${{ github.event.inputs.environment }}" == "Dev/Test" ]; then
+                python transform-and-upload.py -f ./tx-backend/testdata/CX_Testdata_MessagingTest_v${{ github.event.inputs.testdata_version }}.json -s https://tracex-test-submodel-server.dev.demo.catena-x.net -edc https://trace-x-test-edc.dev.demo.catena-x.net -a https://trace-x-registry-test.dev.demo.catena-x.net/semantics/registry/api/v3 -d https://trace-x-test-edc-dataplane.dev.demo.catena-x.net -p traceability-core -k ${{ secrets.TRACE_X_API_KEY_DEV }} --aas3 --edcBPN BPNL00000003CNKC --allowedBPNs BPNL00000003CML1 BPNL00000003CNKC
+            sleep 10
+                python transform-and-upload.py -f ./tx-backend/testdata/CX_Testdata_MessagingTest_v${{ github.event.inputs.testdata_version }}.json -s https://tracex-dev-submodel-server.dev.demo.catena-x.net -edc https://trace-x-edc.dev.demo.catena-x.net -a https://trace-x-registry-dev.dev.demo.catena-x.net/semantics/registry/api/v3 -d https://trace-x-edc-dataplane.dev.demo.catena-x.net -p traceability-core -k ${{ secrets.TRACE_X_API_KEY_DEV }} --aas3 --edcBPN BPNL00000003CML1 --allowedBPNs BPNL00000003CML1 BPNL00000003CNKC
+            sleep 10
+          elif [ "${{ github.event.inputs.environment }}" == "E2E-A/E2E-B" ]; then
+                python transform-and-upload.py -f ./tx-backend/testdata/CX_Testdata_MessagingTest_v${{ github.event.inputs.testdata_version }}.json -s https://tracex-e2e-a-submodel-server.dev.demo.catena-x.net -edc https://trace-x-edc-e2e-a.dev.demo.catena-x.net -a https://trace-x-registry-e2e-a.dev.demo.catena-x.net/semantics/registry/api/v3 -d https://trace-x-edc-e2e-a-dataplane.dev.demo.catena-x.net -p traceability-core -k ${{ secrets.TRACE_X_API_KEY_DEV }} --aas3 --edcBPN BPNL00000003CML1 --allowedBPNs BPNL00000003CML1 BPNL00000003CNKC
+            sleep 10
+                python transform-and-upload.py -f ./tx-backend/testdata/CX_Testdata_MessagingTest_v${{ github.event.inputs.testdata_version }}.json -s https://tracex-e2e-b-submodel-server.dev.demo.catena-x.net -edc https://trace-x-edc-e2e-b.dev.demo.catena-x.net -a https://trace-x-registry-e2e-b.dev.demo.catena-x.net/semantics/registry/api/v3 -d https://trace-x-edc-e2e-b-dataplane.dev.demo.catena-x.net -p traceability-core -k ${{ secrets.TRACE_X_API_KEY_DEV }} --aas3 --edcBPN BPNL00000003CNKC --allowedBPNs BPNL00000003CML1 BPNL00000003CNKC
+            sleep 10
+          elif [ "${{ github.event.inputs.environment }}" == "int-a/int-b" ]; then
+                python transform-and-upload.py -f ./tx-backend/testdata/CX_Testdata_MessagingTest_v${{ github.event.inputs.testdata_version }}.json -s https://tracex-int-a-submodel-server.int.demo.catena-x.net -edc https://trace-x-edc-int-a.int.demo.catena-x.net -a https://trace-x-registry-int-a.int.demo.catena-x.net/semantics/registry/api/v3 -d https://trace-x-edc-int-a-dataplane.int.demo.catena-x.net -p traceability-core -k ${{ secrets.TRACE_X_API_KEY_INT_A }} --aas3 --edcBPN BPNL00000003CML1 --allowedBPNs BPNL00000003CML1 BPNL00000003CNKC BPNL00000003AZQP BPNL00000003CSGV
+            sleep 10
+                python transform-and-upload.py -f ./tx-backend/testdata/CX_Testdata_MessagingTest_v${{ github.event.inputs.testdata_version }}.json -s https://tracex-int-b-submodel-server.int.demo.catena-x.net -edc https://trace-x-edc-int-b.int.demo.catena-x.net -a https://trace-x-registry-int-b.int.demo.catena-x.net/semantics/registry/api/v3 -d https://trace-x-edc-int-b-dataplane.int.demo.catena-x.net -p traceability-core -k ${{ secrets.TRACE_X_API_KEY_INT_B }} --aas3 --edcBPN BPNL00000003CNKC --allowedBPNs BPNL00000003CML1 BPNL00000003CNKC BPNL00000003AZQP BPNL00000003CSGV
+            sleep 10
+          elif [ "${{ github.event.inputs.environment }}" == "association int-a/int-b" ]; then
+                python transform-and-upload.py -f ./tx-backend/testdata/CX_Testdata_MessagingTest_v${{ github.event.inputs.testdata_version }}.json -s https://tracex-int-a-submodel-server.int.catena-x.net -edc https://trace-x-edc-int-a.int.catena-x.net -a https://trace-x-registry-int-a.int.catena-x.net/semantics/registry/api/v3 -d https://trace-x-edc-int-a-dataplane.int.catena-x.net -p traceability-core -k ${{ secrets.TRACE_X_API_KEY_ASSOCIATION_INT }} --aas3 --edcBPN BPNL000000000UKM --allowedBPNs BPNL000000000UKM BPNL000000000DWF BPNL000000000EVQ BPNL00000003CSGV
+            sleep 10
+                python transform-and-upload.py -f ./tx-backend/testdata/CX_Testdata_MessagingTest_v${{ github.event.inputs.testdata_version }}.json -s https://tracex-int-b-submodel-server.int.catena-x.net -edc https://trace-x-edc-int-b.int.catena-x.net -a https://trace-x-registry-int-b.int.catena-x.net/semantics/registry/api/v3 -d https://trace-x-edc-int-b-dataplane.int.catena-x.net -p traceability-core -k ${{ secrets.TRACE_X_API_KEY_ASSOCIATION_INT }} --aas3 --edcBPN BPNL000000000DWF --allowedBPNs BPNL000000000DWF BPNL000000000UKM BPNL000000000EVQ BPNL00000003CSGV
+            sleep 10
+          fi
+        elif [ "${{ github.event.inputs.testdata_upload }}" == "false" ]; then
+          echo "Testdata upload skipped"
+        fi

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -49,6 +49,7 @@ on:
       - 'tx-backend/openapi/**'
       - 'README.md'
       - 'CHANGELOG.md'
+      - 'CHANGELOG.md'
   schedule:
     - cron: '0 1 * * 1-5' # At 01:00 on every day-of-week from Monday through Friday.
 
@@ -64,23 +65,17 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        language: [ 'java' ]
+        language: [ 'java', 'javascript' ]
         # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python', 'ruby' ]
         # Learn more about CodeQL language support at https://git.io/codeql-language-support
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
-
-      - name: Set up JDK 17
-        uses: actions/setup-java@v3
-        with:
-          java-version: '17'
-          distribution: 'temurin'
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v2
+        uses: github/codeql-action/init@v3
         with:
           languages: ${{ matrix.language }}
           # If you wish to specify custom queries, you can do so here or in a config file.
@@ -91,17 +86,24 @@ jobs:
           config-file: ./.github/codeql/codeql-config.yml
           queries: +security-and-quality,security-extended
 
-      - name: Cache maven packages
-        uses: actions/cache@v3
-        with:
-          path: ~/.m2
-          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
-          restore-keys: ${{ runner.os }}-m2
-
       # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
       # If this step fails, then you should remove it and run the build manually (see below)
-      #- name: Autobuild
-      #  uses: github/codeql-action/autobuild@v2
+      # - name: Autobuild
+      #   uses: github/codeql-action/autobuild@v3
+
+      - name: Install frontend dependencies
+        if: ${{ matrix.language == 'javascript' }}
+        run: |
+          cd frontend
+          npm install
+
+      - name: Build frontend
+        if: ${{ matrix.language == 'javascript' }}
+        run: |
+          cd frontend
+          npm run build:prod
+        env:
+          baseHrefPlaceholder: placeholder
 
       # ℹ️ Command-line programs to run using the OS shell.
       # 📚 https://git.io/JvXDl
@@ -110,9 +112,24 @@ jobs:
       #    and modify them (or add more) to build your code if your project
       #    uses a compiled language
 
+      - name: Set up JDK 17
+        if: ${{ matrix.language == 'java' }}
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      - name: Cache maven packages
+        if: ${{ matrix.language == 'java' }}
+        uses: actions/cache@v4
+        with:
+          path: ~/.m2
+          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-m2
+
       - name: Build Package
-        run: |
-          mvn clean package -pl tx-models,tx-backend --batch-mode -DskipTests
+        if: ${{ matrix.language == 'java' }}
+        run: mvn clean package -pl tx-models,tx-backend --batch-mode -DskipTests -s settings.xml -DPACKAGES_ACCESS_USERNAME=${{ secrets.PACKAGES_ACCESS_USERNAME }} -DPACKAGES_ACCESS_TOKEN=${{ secrets.PACKAGES_ACCESS_TOKEN }}
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v2
+        uses: github/codeql-action/analyze@v3

--- a/.github/workflows/dependencies.yaml
+++ b/.github/workflows/dependencies.yaml
@@ -28,17 +28,17 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Set up JDK
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: 17
           distribution: 'temurin'
           cache: 'maven'
 
       - name: Set up Node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 18.x
 
@@ -46,13 +46,13 @@ jobs:
         run: mvn org.eclipse.dash:license-tool-plugin:license-check -Ddash.summary=DEPENDENCIES_BACKEND
 
       - name: Run install
-        uses: borales/actions-yarn@v4
+        uses: borales/actions-yarn@v5
         with:
           cmd: install
           dir: 'frontend'
 
       - name: Generate FE Dependencies file
-        uses: borales/actions-yarn@v4
+        uses: borales/actions-yarn@v5
         with:
           cmd: run dependencies:generate
           dir: 'frontend'
@@ -76,7 +76,7 @@ jobs:
         if: ${{ env.were_files_changed }} == 'true'
 
       - name: Create pull request
-        uses: peter-evans/create-pull-request@v5
+        uses: peter-evans/create-pull-request@v7
         with:
           add-paths: |
             DEPENDENCIES_BACKEND

--- a/.github/workflows/dependency-check.yml
+++ b/.github/workflows/dependency-check.yml
@@ -1,0 +1,110 @@
+#    Copyright (c) 2023 Contributors to the Eclipse Foundation
+#
+#    See the NOTICE file(s) distributed with this work for additional
+#    information regarding copyright ownership.
+#
+#    This program and the accompanying materials are made available under the
+#    terms of the Apache License, Version 2.0 which is available at
+#    https://www.apache.org/licenses/LICENSE-2.0.
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+#
+#  SPDX-License-Identifier: Apache-2.0
+
+name: "[BE] OWASP dependency check"
+
+on:
+  workflow_dispatch: # Trigger manually
+  pull_request:
+
+env:
+  REPO_NAME: ${{ github.repository }}
+  REPO_OWNER: ${{ github.repository_owner }}
+  REPO_URL: ${{ github.server_url }}/${{ github.repository }}
+  GHCR_REGISTRY: ghcr.io
+  JAVA_VERSION: 17
+  DOCKER_HUB_REGISTRY_NAMESPACE: tractusx
+  FAIL_BUILD_ON_CVSS: 7
+  SUPPRESSIONS_FILE: dependency_check/suppressions.xml
+
+jobs:
+  Dependency-analysis:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      contents: read
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/setup-java@v4
+        with:
+          java-version: '${{ env.JAVA_VERSION }}'
+          distribution: 'temurin'
+          cache: 'maven'
+
+      - name: Run mvn clean install
+        run: |
+          mvn -B -DskipTests -pl tx-models,tx-backend -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn\
+          clean install -s settings.xml -DPACKAGES_ACCESS_USERNAME=${{ secrets.PACKAGES_ACCESS_USERNAME }} -DPACKAGES_ACCESS_TOKEN=${{ secrets.PACKAGES_ACCESS_TOKEN }}
+
+      - name: Dependency check tx-backend # possible severity values: <'fail'|'warn'|'ignore'>
+        uses: dependency-check/Dependency-Check_Action@3102a65fd5f36d0000297576acc56a475b0de98d
+        with:
+          project: 'tx-backend'
+          path: 'tx-backend'
+          format: 'HTML'
+          out: 'tx-backend/target/depcheck-report.html'
+          args: >
+            --failOnCVSS ${{ env.FAIL_BUILD_ON_CVSS }}
+            --suppression ${{ env.SUPPRESSIONS_FILE }}
+        env:
+          # actions/setup-java changes JAVA_HOME, so it needs to be reset to match the depcheck image
+          JAVA_HOME: /opt/jdk
+
+      - name: Dependency check tx-models # possible severity values: <'fail'|'warn'|'ignore'>
+        uses: dependency-check/Dependency-Check_Action@3102a65fd5f36d0000297576acc56a475b0de98d
+        with:
+          project: 'tx-models'
+          path: 'tx-models'
+          format: 'HTML'
+          out: 'tx-models/target/depcheck-report.html'
+          args: >
+            --failOnCVSS ${{ env.FAIL_BUILD_ON_CVSS }}
+            --suppression ${{ env.SUPPRESSIONS_FILE }}
+        env:
+          # actions/setup-java changes JAVA_HOME, so it needs to be reset to match the depcheck image
+          JAVA_HOME: /opt/jdk
+
+      - name: Upload results for tx-backend
+        if: always()
+        uses: actions/upload-artifact@master
+        with:
+          name: Depcheck report tx-backend
+          path: tx-backend/target/depcheck-report.html
+
+      - name: Upload results for tx-models
+        if: always()
+        uses: actions/upload-artifact@master
+        with:
+          name: Depcheck report tx-models
+          path: tx-models/target/depcheck-report.html
+
+      - name: Add PR comment
+        uses: mshick/add-pr-comment@v2
+        if: failure()
+        with:
+          message: |
+            ## ‼️ Dependency Check findings ‼️
+            One or more high/critical findings have been found during dependency check. Please check the depenency report:
+            ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+
+      - name: Add PR comment
+        uses: mshick/add-pr-comment@v2
+        if: success()
+        with:
+          message: |
+            ## ✅ No Dependency Check findings were found
+

--- a/.github/workflows/docker-image-branch_frontend.yml
+++ b/.github/workflows/docker-image-branch_frontend.yml
@@ -20,7 +20,6 @@ on:
   pull_request:
 
 env:
-  GHCR_REGISTRY: ghcr.io
   DOCKER_HUB_REGISTRY_NAMESPACE: tractusx
   FRONTEND_IMAGE_DOCKER_HUB: traceability-foss-frontend
 
@@ -37,29 +36,9 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           ref: ${{ github.ref }}
-
-      - name: Login to GHCR Registry
-        env:
-          DOCKER_HUB_USER: ${{ secrets.DOCKER_HUB_USER }}
-        if: env.DOCKER_HUB_USER == ''
-        uses: docker/login-action@v3
-        with:
-          registry: ${{ env.GHCR_REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Build and push for GHCR ${{ env.GHCR_REGISTRY }}/${{ github.repository }}-frontend:${{ github.event.pull_request.head.sha }}
-        env:
-          DOCKER_HUB_USER: ${{ secrets.DOCKER_HUB_USER }}
-        if: env.DOCKER_HUB_USER == ''
-        uses: docker/build-push-action@v5
-        with:
-          context: frontend
-          push: true
-          tags: ${{ env.GHCR_REGISTRY }}/${{ github.repository }}-frontend:${{ github.event.pull_request.head.sha }}
 
       - name: Login to Docker Hub
         env:
@@ -74,8 +53,9 @@ jobs:
         env:
           DOCKER_HUB_USER: ${{ secrets.DOCKER_HUB_USER }}
         if: env.DOCKER_HUB_USER != ''
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
-          context: frontend
+          context: .
+          file: ./frontend/Dockerfile
           push: true
           tags: ${{ env.DOCKER_HUB_REGISTRY_NAMESPACE }}/${{ env.FRONTEND_IMAGE_DOCKER_HUB }}:${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/docker-image-main_backend.yml
+++ b/.github/workflows/docker-image-main_backend.yml
@@ -24,7 +24,6 @@ on:
 
 
 env:
-  GHCR_REGISTRY: ghcr.io
   JAVA_VERSION: 17
   DOCKER_HUB_REGISTRY_NAMESPACE: tractusx
   BACKEND_IMAGE_DOCKER_HUB: traceability-foss
@@ -40,32 +39,12 @@ jobs:
       packages: write
 
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-java@v3
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/setup-java@v4
         with:
           java-version: '${{ env.JAVA_VERSION }}'
           distribution: 'temurin'
           cache: 'maven'
-
-      - name: Login to GHCR Registry
-        env:
-          DOCKER_HUB_USER: ${{ secrets.DOCKER_HUB_USER }}
-        if: env.DOCKER_HUB_USER == ''
-        uses: docker/login-action@v3
-        with:
-          registry: ${{ env.GHCR_REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Build & Push docker image for GHCR ${{ env.GHCR_REGISTRY }}/${{ github.repository }}:${{ github.sha }}
-        env:
-          DOCKER_HUB_USER: ${{ secrets.DOCKER_HUB_USER }}
-        if: env.DOCKER_HUB_USER == ''
-        uses: docker/build-push-action@v5
-        with:
-          context: .
-          push: true
-          tags: ${{ env.GHCR_REGISTRY }}/${{ github.repository }}:${{ github.sha }}
 
       - name: Login to Docker Hub
         env:
@@ -80,7 +59,7 @@ jobs:
         env:
           DOCKER_HUB_USER: ${{ secrets.DOCKER_HUB_USER }}
         if: env.DOCKER_HUB_USER != ''
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
           context: .
           push: true
@@ -90,9 +69,9 @@ jobs:
         env:
           DOCKER_HUB_USER: ${{ secrets.DOCKER_HUB_USER }}
         if: env.DOCKER_HUB_USER != ''
-        uses: peter-evans/dockerhub-description@v3
+        uses: peter-evans/dockerhub-description@v4
         with:
           username: ${{ secrets.DOCKER_HUB_USER }}
           password: ${{ secrets.DOCKER_HUB_TOKEN }}
           repository: ${{ env.DOCKER_HUB_REGISTRY_NAMESPACE }}/${{ env.BACKEND_IMAGE_DOCKER_HUB }}
-          readme-filepath: README.md
+          readme-filepath: ./DOCKER_NOTICE.md

--- a/.github/workflows/docker-image-main_frontend.yml
+++ b/.github/workflows/docker-image-main_frontend.yml
@@ -22,7 +22,6 @@ on:
     branches: main
 
 env:
-  GHCR_REGISTRY: ghcr.io
   DOCKER_HUB_USER: ${{ secrets.DOCKER_HUB_USER }}
   DOCKER_HUB_REGISTRY_NAMESPACE: tractusx
   FRONTEND_IMAGE_DOCKER_HUB: traceability-foss-frontend
@@ -40,27 +39,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
-
-      - name: Login to GHCR Registry
-        env:
-          DOCKER_HUB_USER: ${{ secrets.DOCKER_HUB_USER }}
-        if: env.DOCKER_HUB_USER == ''
-        uses: docker/login-action@v3
-        with:
-          registry: ${{ env.GHCR_REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Build and push to GHCR Registry ${{ env.GHCR_REGISTRY }}/${{ github.repository }}-frontend:${{ github.sha }}
-        env:
-          DOCKER_HUB_USER: ${{ secrets.DOCKER_HUB_USER }}
-        if: env.DOCKER_HUB_USER == ''
-        uses: docker/build-push-action@v5
-        with:
-          context: frontend
-          push: true
-          tags: ${{ env.GHCR_REGISTRY }}/${{ github.repository }}-frontend:${{ github.sha }}
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Login to Docker Hub
         env:
@@ -75,14 +54,15 @@ jobs:
         env:
           DOCKER_HUB_USER: ${{ secrets.DOCKER_HUB_USER }}
         if: env.DOCKER_HUB_USER != ''
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
-          context: frontend
+          context: .
+          file: ./frontend/Dockerfile
           push: true
           tags: ${{ env.DOCKER_HUB_REGISTRY_NAMESPACE }}/${{ env.FRONTEND_IMAGE_DOCKER_HUB }}:${{ github.sha }}
 
       - name: Update Docker Hub description
-        uses: peter-evans/dockerhub-description@v3
+        uses: peter-evans/dockerhub-description@v4
         env:
           DOCKER_HUB_USER: ${{ secrets.DOCKER_HUB_USER }}
         if: env.DOCKER_HUB_USER != ''
@@ -90,4 +70,4 @@ jobs:
           username: ${{ env.DOCKER_HUB_USER }}
           password: ${{ secrets.DOCKER_HUB_TOKEN }}
           repository: ${{ env.DOCKER_HUB_REGISTRY_NAMESPACE }}/${{ env.FRONTEND_IMAGE_DOCKER_HUB }}
-          readme-filepath: README.md
+          readme-filepath: ./frontend/DOCKER_NOTICE.md

--- a/.github/workflows/docker-image-tag-release.yaml
+++ b/.github/workflows/docker-image-tag-release.yaml
@@ -25,7 +25,6 @@ on:
 
 env:
   TAG_NAME: "${{ github.ref_name }}"
-  GHCR_REGISTRY: ghcr.io
   JAVA_VERSION: 17
   DOCKER_HUB_REGISTRY_NAMESPACE: tractusx
   BACKEND_IMAGE_DOCKER_HUB: traceability-foss
@@ -43,27 +42,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
-
-      - name: Login to GHCR Registry
-        env:
-          DOCKER_HUB_USER: ${{ secrets.DOCKER_HUB_USER }}
-        if: env.DOCKER_HUB_USER == ''
-        uses: docker/login-action@v3
-        with:
-          registry: ${{ env.GHCR_REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Build and push to GHCR Registry ${{ env.GHCR_REGISTRY }}/${{ github.repository }}-frontend:${{ env.TAG_NAME }} and :latest
-        env:
-          DOCKER_HUB_USER: ${{ secrets.DOCKER_HUB_USER }}
-        if: env.DOCKER_HUB_USER == ''
-        uses: docker/build-push-action@v5
-        with:
-          context: frontend
-          push: true
-          tags: ${{ env.GHCR_REGISTRY }}/${{ github.repository }}-frontend:${{ env.TAG_NAME }}, ${{ env.GHCR_REGISTRY }}/${{ github.repository }}-frontend:latest
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Login to Docker Hub
         env:
@@ -78,9 +57,10 @@ jobs:
         env:
           DOCKER_HUB_USER: ${{ secrets.DOCKER_HUB_USER }}
         if: env.DOCKER_HUB_USER != ''
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
-          context: frontend
+          context: .
+          file: ./frontend/Dockerfile
           push: true
           tags: ${{ env.DOCKER_HUB_REGISTRY_NAMESPACE }}/${{ env.FRONTEND_IMAGE_DOCKER_HUB }}:${{ env.TAG_NAME }}, ${{ env.DOCKER_HUB_REGISTRY_NAMESPACE }}/${{ env.FRONTEND_IMAGE_DOCKER_HUB }}:latest
 
@@ -88,12 +68,12 @@ jobs:
         env:
           DOCKER_HUB_USER: ${{ secrets.DOCKER_HUB_USER }}
         if: env.DOCKER_HUB_USER != ''
-        uses: peter-evans/dockerhub-description@v3
+        uses: peter-evans/dockerhub-description@v4
         with:
           username: ${{ secrets.DOCKER_HUB_USER }}
           password: ${{ secrets.DOCKER_HUB_TOKEN }}
           repository: ${{ env.DOCKER_HUB_REGISTRY_NAMESPACE }}/${{ env.FRONTEND_IMAGE_DOCKER_HUB }}
-          readme-filepath: README.md
+          readme-filepath: ./frontend/DOCKER_NOTICE.md
 
   Release-docker-image-backend:
     runs-on: ubuntu-latest
@@ -105,39 +85,19 @@ jobs:
       packages: write
 
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-java@v3
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/setup-java@v4
         with:
           java-version: '${{ env.JAVA_VERSION }}'
           distribution: 'temurin'
           cache: 'maven'
 
       - name: Cache maven packages
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/.m2
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
           restore-keys: ${{ runner.os }}-m2
-
-      - name: Login to GHCR Registry
-        env:
-          DOCKER_HUB_USER: ${{ secrets.DOCKER_HUB_USER }}
-        if: env.DOCKER_HUB_USER == ''
-        uses: docker/login-action@v3
-        with:
-          registry: ${{ env.GHCR_REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Build & push docker image for GHCR Registry ${{ env.GHCR_REGISTRY }}/${{ github.repository }}:${{ env.TAG_NAME }}
-        env:
-          DOCKER_HUB_USER: ${{ secrets.DOCKER_HUB_USER }}
-        if: env.DOCKER_HUB_USER == ''
-        uses: docker/build-push-action@v5
-        with:
-          context: .
-          push: true
-          tags: ${{ env.GHCR_REGISTRY }}/${{ github.repository }}:${{ env.TAG_NAME }}, ${{ env.GHCR_REGISTRY }}/${{ github.repository }}:latest
 
       - name: Login to Docker Hub
         env:
@@ -152,7 +112,7 @@ jobs:
         env:
           DOCKER_HUB_USER: ${{ secrets.DOCKER_HUB_USER }}
         if: env.DOCKER_HUB_USER != ''
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
           context: .
           push: true
@@ -162,10 +122,10 @@ jobs:
         env:
           DOCKER_HUB_USER: ${{ secrets.DOCKER_HUB_USER }}
         if: env.DOCKER_HUB_USER != ''
-        uses: peter-evans/dockerhub-description@v3
+        uses: peter-evans/dockerhub-description@v4
         with:
           username: ${{ secrets.DOCKER_HUB_USER }}
           password: ${{ secrets.DOCKER_HUB_TOKEN }}
           repository: ${{ env.DOCKER_HUB_REGISTRY_NAMESPACE }}/${{env.BACKEND_IMAGE_DOCKER_HUB}}
-          readme-filepath: README.md
+          readme-filepath: ./DOCKER_NOTICE.md
 

--- a/.github/workflows/e2e-tests-xray_frontend.yml
+++ b/.github/workflows/e2e-tests-xray_frontend.yml
@@ -16,65 +16,80 @@
 #  SPDX-License-Identifier: Apache-2.0
 
 # Require to set secrets:
-#  - ORG_IRS_JIRA_USERNAME
-#  - ORG_IRS_JIRA_PASSWORD
+#  - ASSOCIATION_SUPERVISOR_CLIENT_ID
+#  - ASSOCIATION_SUPERVISOR_PASSWORD
 name: "[FE][TEST][E2E]- Cypress"
 
 on:
   # triggered manually by Test Manager
   workflow_dispatch:
-    inputs:
-      jira_filter_id:
-        description: 'Jira filter ID to fetch test scenarios'
-        required: false
-        # by default, we use this filter: https://jira.catena-x.net/issues/?filter=11645
-        default: 11645
   # or automatically by merge to main
-  #push:
-    branches: main
+  push:
+    branches:
+      - main
     paths:
       - 'frontend/**'
 
 jobs:
   install:
     runs-on: ubuntu-latest
+    outputs:
+      http_result: ${{ steps.download.outputs.http_response }}
     defaults:
       run:
         working-directory: frontend
     # Install YARN dependencies, cache them correctly
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
-      - name: Use Node.js 18.x
-        uses: actions/setup-node@v3
+      - name: Use Node.js 20.x
+        uses: actions/setup-node@v4
         with:
-          node-version: 18.x
+          node-version: 20.x
 
       - name: Run yarn install
-        uses: Borales/actions-yarn@v4.2.0
+        uses: Borales/actions-yarn@v5
         with:
           cmd: install # will run `yarn install` command
 
-    # Fetch feature files
+      # Fetch feature files
       - name: Fetch .feature files from Jira Xray
+        id: download
         env:
-          JIRA_USERNAME: ${{ secrets.ORG_IRS_JIRA_USERNAME }}
-          JIRA_PASSWORD: ${{ secrets.ORG_IRS_JIRA_PASSWORD }}
-          JIRA_FILTER_ID: ${{ github.event.inputs.jira_filter_id }}
+          JIRA_USERNAME: ${{ secrets.ASSOCIATION_TX_JIRA_USERNAME }}
+          JIRA_PASSWORD: ${{ secrets.ASSOCIATION_TX_JIRA_PASSWORD }}
         working-directory: frontend
-        run: ./scripts/xray-download-feature-files.sh
+        run: |
+          token=$(curl -H "Content-Type: application/json" -X POST \
+          --data "{ \"client_id\": \"$JIRA_USERNAME\",\"client_secret\": \"$JIRA_PASSWORD\" }" \
+          https://xray.cloud.getxray.app/api/v2/authenticate | tr -d '"')
+
+          export HTTP_RESULT=$(curl -s --show-error -w "%{http_code}" --header "Authorization: Bearer $token" \
+          "https://xray.cloud.getxray.app/api/v2/export/cucumber?filter=10007&fz=true" -o features.zip)
+
+          [[ $HTTP_RESULT == 200 || $HTTP_RESULT == 400 ]]
+          echo "::set-output name=http_response::$HTTP_RESULT"
+
+      - name: Unzip feature files
+        if: ${{ steps.download.outputs.http_response == '200' }}
+        working-directory: frontend
+        run: |
+          unzip -o features.zip -d cypress/e2e
+          rm -f features.zip
 
       - name: Save cypress/e2e folder
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: cypress - e2e
           if-no-files-found: error
           path: frontend/cypress/e2e
+          overwrite: true
 
   cypress-run-chrome:
     timeout-minutes: 15
     runs-on: ubuntu-latest
+    if: ${{ needs.install.outputs.http_result == '200' }}
     defaults:
       run:
         working-directory: frontend
@@ -87,160 +102,73 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Download the cypress/e2e folder
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: cypress - e2e
           path: frontend/cypress/e2e
 
-      - name: Use Node.js 18.x
-        uses: actions/setup-node@v3
+      - name: Use Node.js 20.x
+        uses: actions/setup-node@v4
         with:
-          node-version: 18.x
+          node-version: 20.x
+
+      - name: Install Angular CLI
+        run: npm install -g @angular/cli
+
+      - name: Run yarn install
+        uses: Borales/actions-yarn@v5
+        with:
+          cmd: install # will run `yarn install` command
+          dir: frontend
+
+      - name: Start Frontend Application
+        working-directory: frontend
+        run: |
+          npm run start:auth:e2ea &
+          sleep 60 &&
+          curl http://localhost:4200 -I
+
 
       - name: Cypress run all tests
-        uses: cypress-io/github-action@v6.5.0 # use the explicit version number
+        uses: cypress-io/github-action@v6.7.16 # use the explicit version number
         with:
-          start: npm start
-          wait-on: "http://localhost:4200"
-          wait-on-timeout: 120
           browser: chrome
           working-directory: frontend
+          # using wait-on parameter causes "Error: connect ECONNREFUSED 127.0.0.1:4200"
+        env:
+          CYPRESS_SUPERVISOR_LOGIN: ${{ secrets.ASSOCIATION_SUPERVISOR_TX_A_CLIENT_ID }}
+          CYPRESS_SUPERVISOR_PW: ${{ secrets.ASSOCIATION_SUPERVISOR_TX_A_PASSWORD }}
+          CYPRESS_ADMIN_LOGIN: ${{ secrets.TRACE_X_ADMIN_LOGIN }}
+          CYPRESS_ADMIN_PW: ${{ secrets.TRACE_X_ADMIN_PW }}
+          CYPRESS_USER_LOGIN: ${{ secrets.TRACE_X_USER_LOGIN }}
+          CYPRESS_USER_PW: ${{ secrets.TRACE_X_USER_PW }}
+          CYPRESS_REDIRECT_URI: https://traceability-portal-int-a.int.catena-x.net/dashboard
 
       - name: Submit results to Xray
         # we don't want to submit results to xray when it was run by PR
         if: github.event_name != 'pull_request' && (success() || failure())
         env:
-          JIRA_USERNAME: ${{ secrets.ORG_IRS_JIRA_USERNAME }}
-          JIRA_PASSWORD: ${{ secrets.ORG_IRS_JIRA_PASSWORD }}
+          JIRA_USERNAME: ${{ secrets.ASSOCIATION_TX_JIRA_USERNAME }}
+          JIRA_PASSWORD: ${{ secrets.ASSOCIATION_TX_JIRA_PASSWORD }}
         run: |
-          ./scripts/xray-push-test-results.sh
+          token=$(curl -H "Content-Type: application/json" -X POST \
+          --data "{ \"client_id\": \"$JIRA_USERNAME\",\"client_secret\": \"$JIRA_PASSWORD\" }" \
+          https://xray.cloud.getxray.app/api/v2/authenticate | tr -d '"')
+
+          curl --request POST \
+          --header 'Content-Type: application/json' \
+          --header "Authorization: Bearer $token" \
+          --data-binary '@cypress/reports/cucumber-report.json' \
+          "https://xray.cloud.getxray.app/api/v2/import/execution/cucumber"
 
       - name: Archive cypress artifacts
         if: success() || failure()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: cypress generated files - chrome
-          path: |
-            frontend/cypress/videos/
-            frontend/cypress/screenshots/
-
-  cypress-run-firefox:
-    timeout-minutes: 15
-    runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: frontend
-    container:
-      # if you need to change image please make sure use the same version in all places
-      # (here and in cypress/Dockerfile)
-      image: cypress/browsers:node16.16.0-chrome107-ff107-edge
-      options: --user 1001
-    needs: install
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Download the cypress/e2e folder
-        uses: actions/download-artifact@v3
-        with:
-          name: cypress - e2e
-          path: frontend/cypress/e2e
-
-      - name: Use Node.js 18.x
-        uses: actions/setup-node@v3
-        with:
-          node-version: 18.x
-
-      - name: Cypress run all tests
-        uses: cypress-io/github-action@v6.5.0 # use the explicit version number
-        with:
-          start: npm start
-          wait-on: "http://localhost:4200"
-          wait-on-timeout: 120
-          browser: firefox
-          working-directory: frontend
-
-      - name: Submit results to Xray
-        # we don't want to submit results to xray when it was run by PR
-        if: github.event_name != 'pull_request' && (success() || failure())
-        env:
-          JIRA_USERNAME: ${{ secrets.ORG_IRS_JIRA_USERNAME }}
-          JIRA_PASSWORD: ${{ secrets.ORG_IRS_JIRA_PASSWORD }}
-        run: |
-          ./scripts/xray-push-test-results.sh
-
-      - name: Archive cypress artifacts
-        if: success() || failure()
-        uses: actions/upload-artifact@v3
-        with:
-          name: cypress generated files - firefox
-          path: |
-            frontend/cypress/videos/
-            frontend/cypress/screenshots/
-
-  cypress-run-webkit:
-    timeout-minutes: 15
-    runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: frontend
-    needs: install
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Download the cypress/e2e folder
-        uses: actions/download-artifact@v3
-        with:
-          name: cypress - e2e
-          path: frontend/cypress/e2e
-
-# commented because if we use it here, we face with that problem:
-# "http://localhost:4200 timed out on retry 151 of 5, elapsed 150449ms, limit 150000ms
-#  Error: connect ECONNREFUSED 127.0.0.1:4200"
-
-#      - name: Use Node.js 18.x
-#        uses: actions/setup-node@v3
-#        with:
-#          node-version: 18.x
-
-      - name: Use Node.js 16.x
-        uses: actions/setup-node@v3
-        with:
-          node-version: 16.x
-
-      # https://docs.cypress.io/guides/guides/launching-browsers#Linux-Dependencies
-      - name: Install additional dependencies
-        run: npx playwright install --with-deps webkit
-
-      - name: Cypress run all tests
-        uses: cypress-io/github-action@v6.5.0 # use the explicit version number
-        with:
-          start: npm start
-          wait-on: "http://localhost:4200"
-          wait-on-timeout: 120
-          browser: webkit
-          working-directory: frontend
-
-      - name: Submit results to Xray
-        # we don't want to submit results to xray when it was run by PR
-        if: github.event_name != 'pull_request' && (success() || failure())
-        env:
-          JIRA_USERNAME: ${{ secrets.ORG_IRS_JIRA_USERNAME }}
-          JIRA_PASSWORD: ${{ secrets.ORG_IRS_JIRA_PASSWORD }}
-        run: |
-          ./scripts/xray-push-test-results.sh
-
-      - name: Archive cypress artifacts
-        if: success() || failure()
-        uses: actions/upload-artifact@v3
-        with:
-          name: cypress generated files - webkit
           path: |
             frontend/cypress/videos/
             frontend/cypress/screenshots/

--- a/.github/workflows/eclipse-dash.yml
+++ b/.github/workflows/eclipse-dash.yml
@@ -43,7 +43,7 @@ jobs:
       packages: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: IP dependency check with eclipse dash tool
         run: cd frontend && npm run dependencies:generate
@@ -51,23 +51,23 @@ jobs:
 
       - name: upload results
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           path: DEPENDENCIES_FRONTEND
 
   build-backend:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: '17'
           distribution: 'temurin'
 
       - name: Cache maven packages
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/.m2
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
@@ -75,10 +75,11 @@ jobs:
 
       - name: Check dependencies
         run: |
-          mvn package org.eclipse.dash:license-tool-plugin:license-check -DskipTests=true -Ddash.summary=DEPENDENCIES_BACKEND -Ddash.fail=true
+          mvn package org.eclipse.dash:license-tool-plugin:license-check -DskipTests=true -Ddash.summary=DEPENDENCIES_BACKEND -Ddash.fail=true -s settings.xml -DPACKAGES_ACCESS_USERNAME=${{ secrets.PACKAGES_ACCESS_USERNAME }} -DPACKAGES_ACCESS_TOKEN=${{ secrets.PACKAGES_ACCESS_TOKEN }}
 
       - name: upload results
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           path: DEPENDENCIES_BACKEND
+          overwrite: true

--- a/.github/workflows/helm-chart-release.yaml
+++ b/.github/workflows/helm-chart-release.yaml
@@ -19,9 +19,6 @@ name: "[BE][FE][RELEASE][HELM] Release Helm Charts"
 
 on:
   workflow_dispatch: # Trigger manually
-  push:
-    tags:
-      - '[0-9]+.[0-9]+.[0-9]+'
 
 jobs:
   Get-helm-charts-versions:
@@ -33,7 +30,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0
 
@@ -61,7 +58,7 @@ jobs:
       RELEASE_VERSION: "${{needs.Get-helm-charts-versions.outputs.current_version}}"
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0
 
@@ -71,7 +68,7 @@ jobs:
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
 
       - name: Install Helm
-        uses: azure/setup-helm@v3
+        uses: azure/setup-helm@v4
         with:
           version: v3.10.0
 
@@ -80,10 +77,11 @@ jobs:
           helm repo add bitnami https://charts.bitnami.com/bitnami
           helm repo add runix https://helm.runix.net
           helm repo add item-relationship-service https://eclipse-tractusx.github.io/item-relationship-service
-          helm repo add tx-item-relationship-service https://catenax-ng.github.io/tx-item-relationship-service
 
       - name: Run chart-releaser
-        uses: helm/chart-releaser-action@v1.5.0
+        uses: helm/chart-releaser-action@v1.7.0
+        with:
+          mark_as_latest: false
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
           CR_RELEASE_NAME_TEMPLATE: "${{ env.RELEASE_VERSION }}"

--- a/.github/workflows/helm-test.yaml
+++ b/.github/workflows/helm-test.yaml
@@ -18,10 +18,20 @@
 name: "[BE][FE][HELM] Lint and Test"
 
 on:
+  push:
+    branches:
+      - main
   pull_request:
     paths:
       - 'charts/**'
+
   workflow_dispatch:
+    inputs:
+      node_image:
+        description: 'kindest/node image for k8s kind cluster'
+        default: 'kindest/node:v1.27.3'
+        required: false
+        type: string
   workflow_call: # Trigger by another workflow
     inputs:
       node_image:
@@ -41,7 +51,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0
 
@@ -52,26 +62,30 @@ jobs:
           version: v0.20.0
 
       - name: Build & push Image App to KinD
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
           context: .
           push: true
           tags: ${{ env.REGISTRY }}/${{ env.APP_NAME}}:${{ env.TAG }}
+          secrets: |
+            "PACKAGES_ACCESS_USERNAME=${{ secrets.PACKAGES_ACCESS_USERNAME }}"
+            "PACKAGES_ACCESS_TOKEN=${{ secrets.PACKAGES_ACCESS_TOKEN }}"
 
       - name: Build & push Image Frontend to KinD
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
-          context: ./frontend
+          context: .
+          file: ./frontend/Dockerfile
           push: true
           tags: ${{ env.REGISTRY }}/${{ env.APP_FRONTEND_NAME }}:${{ env.TAG }}
 
       - name: Set up Helm
-        uses: azure/setup-helm@v3
+        uses: azure/setup-helm@v4
         with:
           version: v3.9.3
 
       - name: Set up chart-testing
-        uses: helm/chart-testing-action@v2.4.0
+        uses: helm/chart-testing-action@v2.6.1
 
       - name: Run chart-testing (list-changed)
         id: list-changed

--- a/.github/workflows/helm-upgrade.yaml
+++ b/.github/workflows/helm-upgrade.yaml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0
 
@@ -36,7 +36,7 @@ jobs:
         uses: container-tools/kind-action@v2
 
       - name: Set up Helm
-        uses: azure/setup-helm@v3
+        uses: azure/setup-helm@v4
         with:
           version: v3.9.3
 

--- a/.github/workflows/jira-publish-release.yaml
+++ b/.github/workflows/jira-publish-release.yaml
@@ -34,7 +34,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Set current date as env variable
         run: echo "NOW=$(date +'%Y-%m-%d')" >> $GITHUB_ENV

--- a/.github/workflows/kics.yml
+++ b/.github/workflows/kics.yml
@@ -44,7 +44,7 @@ jobs:
       security-events: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: KICS scan
         uses: checkmarx/kics-github-action@master
@@ -77,7 +77,7 @@ jobs:
       # Upload findings to GitHub Advanced Security Dashboard
       - name: Upload SARIF file for GitHub Advanced Security Dashboard
         if: always()
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: kicsResults/results.sarif
 
@@ -93,14 +93,14 @@ jobs:
       security-events: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: KICS scan
         uses: checkmarx/kics-github-action@master
         with:
           # Scanning directory .
           path: "./tx-backend"
-          exclude_queries: 2ea04bef-c769-409e-9179-ee3a50b5c0ac,6998389e-66b2-473d-8d05-c8d71ac4d04d,a8e859da-4a43-4e7f-94b8-25d6e3bf8e90,d172a060-8569-4412-8045-3560ebd477e8,2e9b6612-8f69-42e0-a5b8-ed17739c2f3a,d172a060-8569-4412-8045-3560ebd477e8,9f88c88d-824d-4d9a-b985-e22977046042,8c8261c2-19a9-4ef7-ad37-b8bc7bdd4d85,181bd815-767e-4e95-a24d-bb3c87328e19,00b78adf-b83f-419c-8ed8-c6018441dd3a,86e3702f-c868-44b2-b61d-ea5316c18110
+          exclude_queries: 2ea04bef-c769-409e-9179-ee3a50b5c0ac,6998389e-66b2-473d-8d05-c8d71ac4d04d,a8e859da-4a43-4e7f-94b8-25d6e3bf8e90,d172a060-8569-4412-8045-3560ebd477e8,2e9b6612-8f69-42e0-a5b8-ed17739c2f3a,d172a060-8569-4412-8045-3560ebd477e8,9f88c88d-824d-4d9a-b985-e22977046042,8c8261c2-19a9-4ef7-ad37-b8bc7bdd4d85,181bd815-767e-4e95-a24d-bb3c87328e19,00b78adf-b83f-419c-8ed8-c6018441dd3a,86e3702f-c868-44b2-b61d-ea5316c18110,a92be1d5-d762-484a-86d6-8cd0907ba100,4f31dd9f-2cc3-4751-9b53-67e4af83dac0,561710b1-b845-4562-95ce-2397a05ccef4,237402e2-c2f0-46c9-9cf5-286160cf7bfc,2bd608ae-8a1f-457f-b710-c237883cb313
           enable_comments: true
           # Fail on HIGH severity results
           fail_on: high
@@ -122,7 +122,7 @@ jobs:
       # Upload findings to GitHub Advanced Security Dashboard
       - name: Upload SARIF file for GitHub Advanced Security Dashboard
         if: always()
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: kicsResults/results.sarif
 

--- a/.github/workflows/publish-docker-image.yaml
+++ b/.github/workflows/publish-docker-image.yaml
@@ -15,7 +15,7 @@
 #
 #  SPDX-License-Identifier: Apache-2.0
 
-name: "[BE][BUILT][DEPLOYMENT] Pull request"
+name: "[BE][BUILT] Publish Docker image"
 
 on:
   workflow_dispatch: # Trigger manually
@@ -28,36 +28,7 @@ env:
   BACKEND_IMAGE_DOCKER_HUB: traceability-foss
 
 jobs:
-  Check-Pom-for-snapshot-versions:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout Repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
-
-      - name: Check pom for -SNAPSHOT
-        id: pom-version
-        run: |
-          snapshot_count_root_pom=$(sed -n '/<properties>/,/properties>/p' pom.xml | grep -o '\-SNAPSHOT' | wc -l)
-          if (( $snapshot_count_root_pom > 1 )); then
-            echo "pom_changed=true" >> $GITHUB_OUTPUT
-          else
-            echo "pom_changed=false" >> $GITHUB_OUTPUT
-          fi
-
-      - name: Create Review Comment
-        uses: ntsd/auto-request-changes-action@v3
-        if: steps.pom-version.outputs.pom_changed == 'true'
-        with:
-          github-token: "${{ secrets.GITHUB_TOKEN }}"
-          review-message: "Please remove -SNAPSHOT from property versions. You can find them in pom.xml(tx-root)."
-
-      - name: Print environment variables
-        id: print-env-vars
-        run: |
-          echo ${{steps.pom-version.outputs.pom_changed}}
-
   Publish-docker-image:
-   # needs: [ "Test-and-Sonar" ]
     runs-on: ubuntu-latest
     defaults:
       run:

--- a/.github/workflows/publish-documentation.yaml
+++ b/.github/workflows/publish-documentation.yaml
@@ -19,6 +19,9 @@ name: "[BE][FE][DOCUMENTATION] Publish documentation"
 
 on:
   workflow_dispatch: # Trigger manually
+  pull_request:
+    paths:
+      - 'docs/**'
   push:
     branches:
       - main
@@ -34,61 +37,85 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0
 
       - name: Setup Graphviz
-        uses: ts-graphviz/setup-graphviz@v1
+        uses: ts-graphviz/setup-graphviz@v2
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: '17'
           distribution: 'temurin'
 
       - name: Setup Node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
-          node-version: 16
+          node-version: 20
 
       - name: Cache maven packages
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/.m2
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
           restore-keys: ${{ runner.os }}-m2
+
 
       - name: Build with Maven
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
         run: |
           mvn -f docs/pom.xml --batch-mode generate-resources
+
       - name: Install Asciidoctor Reducer
         run: |
           sudo gem install asciidoctor-reducer
+
       - name: Reduce docs
         run: |
           echo $LANG
           locale
           asciidoctor-reducer -o docs/target/adminguide.adoc docs/src/docs/administration/administration-guide.adoc
           asciidoctor-reducer -o docs/target/arc42.adoc docs/src/docs/arc42/full.adoc
+          asciidoctor-reducer -o docs/target/user-manual.adoc docs/src/docs/user/user-manual.adoc
+
+      - name: Cache plantuml jar
+        uses: actions/cache@v4
+        with:
+          path: plantuml.jar
+          key: ${{ runner.os }}-file-${{ hashFiles('plantuml.jar') }}
+
       - name: Download PlantUML jar
         run: |
           wget -O plantuml.jar https://sourceforge.net/projects/plantuml/files/plantuml.jar/download
+
       - name: Place PlantUML jar in specific path
         run: |
           mv plantuml.jar docs/src/diagram-replacer/
+
       - name: Extract PNG-Images with PlantUML and replace PlantUML Code inside docs with PNG-Images
         working-directory: docs/src/diagram-replacer/
         run: |
           node extract.js
           node replace.js
+
       - name: Convert to Markdown
         run: |
           npx downdoc -o docs/target/generated-docs/adminguide.md docs/src/diagram-replacer/generated-adocs/adminguide.adoc
           npx downdoc -o docs/target/generated-docs/arc42.md docs/src/diagram-replacer/generated-adocs/arc42.adoc
-          npx downdoc -o docs/target/generated-docs/user-manual.md docs/src/docs/user/user-manual.adoc
+          npx downdoc -o docs/target/generated-docs/user-manual.md docs/src/diagram-replacer/generated-adocs/user-manual.adoc
+
+      - name: Upload Markdown
+        if: always()
+        uses: actions/upload-artifact@master
+        with:
+          path: |
+            docs/target/generated-docs/arc42.md
+            docs/target/generated-docs/adminguide.md
+            docs/target/generated-docs/user-manual.md
+
       - name: MD files post-processing
         working-directory: docs/src/post-processing/
         run: |
@@ -97,18 +124,38 @@ jobs:
           node fix_no_emphasis.js
           node fix_https_links.js
           node fix_relative_links.js https://$GITHUB_REPOSITORY_OWNER.github.io/$REPO/docs
+
       - name: MD linting
         run: |
-          npm install markdownlint-cli2
+          npm install markdownlint-cli2@0.11.0
           npx markdownlint-cli2-config docs/.markdownlint.yaml docs/target/generated-docs/adminguide.md
           npx markdownlint-cli2-config docs/.markdownlint.yaml docs/target/generated-docs/arc42.md
           npx markdownlint-cli2-config docs/.markdownlint.yaml docs/target/generated-docs/user-manual.md
+
       - name: Move assets to target directory
         run: |
           mv docs/src/diagram-replacer/assets/ docs/target/generated-docs/assets/
-      - name: GitHub Pages action
-        uses: peaceiris/actions-gh-pages@v3.9.3
+
+      - name: Generate Swagger UI
+        uses: Legion2/swagger-ui-action@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          output: swagger-ui
+          spec-file: docs/api/traceability-foss-backend.json
+
+      - name: Update documentation on GitHub Pages
+        if: github.ref == 'refs/heads/main'
+        uses: peaceiris/actions-gh-pages@v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: "./docs/target/generated-docs"
           destination_dir: "docs"
+
+      - name: Deploy Swagger UI to GitHub Pages
+        if: github.ref == 'refs/heads/main'
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: "swagger-ui"
+          destination_dir: "docs/swagger-ui"

--- a/.github/workflows/publish-swagger-hub.yml
+++ b/.github/workflows/publish-swagger-hub.yml
@@ -1,0 +1,54 @@
+name: "Publish OpenAPI to Swaggerhub"
+
+on:
+  workflow_call:
+    inputs:
+      version:
+        required: true
+        description: Version that will be published to Swaggerhub
+        type: string
+
+jobs:
+  swagger-api:
+    runs-on: ubuntu-latest
+    env:
+      SWAGGERHUB_API_KEY: ${{ secrets.SWAGGERHUB_API_KEY }}
+      SWAGGERHUB_USER: ${{ secrets.SWAGGERHUB_USER }}
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      - name: Setup node
+        uses: actions/setup-node@v4
+
+      - name: Install Swagger CLI
+        run: |
+          npm i -g swaggerhub-cli
+
+      - name: Extract versions
+        run: |
+          export VERSION="${{ inputs.version }}"
+          echo "VERSION=${VERSION}" >> "$GITHUB_ENV"
+
+      # create API, will fail if exists
+      - name: Create API
+        continue-on-error: true
+        run: |
+          swaggerhub api:create ${{ env.SWAGGERHUB_USER }}/trace-x/${{ env.VERSION }} -f tx-backend/openapi/traceability-foss-backend.json --visibility=public --published=unpublish
+
+      # Post the API to SwaggerHub as "unpublished", because published APIs cannot be overwritten
+      - name: Publish API Specs to SwaggerHub
+        run: |
+          if [[ ${{ env.VERSION }} != *-SNAPSHOT ]]; then
+            echo "[INFO] - no snapshot, will set the API to 'published'";
+            swaggerhub api:update ${{ env.SWAGGERHUB_USER }}/trace-x/${{ env.VERSION }} -f tx-backend/openapi/traceability-foss-backend.json --visibility=public --published=publish
+            swaggerhub api:setdefault ${{ env.SWAGGERHUB_USER }}/trace-x/${{ env.VERSION }}
+          else
+            echo "[INFO] - snapshot, will set the API to 'unpublished'";
+            swaggerhub api:update ${{ env.SWAGGERHUB_USER }}/trace-x/${{ env.VERSION }} -f tx-backend/openapi/traceability-foss-backend.json --visibility=public --published=unpublish
+          fi

--- a/.github/workflows/pull_request_issue.yml
+++ b/.github/workflows/pull_request_issue.yml
@@ -1,0 +1,80 @@
+#    Copyright (c) 2023 Contributors to the Eclipse Foundation
+#
+#    See the NOTICE file(s) distributed with this work for additional
+#    information regarding copyright ownership.
+#
+#    This program and the accompanying materials are made available under the
+#    terms of the Apache License, Version 2.0 which is available at
+#    https://www.apache.org/licenses/LICENSE-2.0.
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+#
+#  SPDX-License-Identifier: Apache-2.0
+
+name: Connect Pull Request with Github Issue Workflow
+on:
+  workflow_dispatch: # Trigger manually
+  pull_request:
+    types: [opened]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: latest
+
+      - name: Install Dependencies
+        run: npm install github
+
+      - name: Extract Numbers from PR Title and create description
+        id: extract_numbers
+        run: |
+
+          PR_TITLE=$(echo "${{ github.event.pull_request.title }}" | tr '[:upper:]' '[:lower:]')
+          if [[ $PR_TITLE == *xxx* ]]; then
+            echo "skip workflow"
+            echo "" > pr_description.txt
+          else
+            PR_NUMBER=$(echo "$PR_TITLE" | grep -Eo '[0-9]{3,}' | head -n 1)
+            echo "resolves traceability-foss#$PR_NUMBER" > pr_description.txt
+          fi
+
+      - name: Update Pull Request
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const fs = require('fs');
+
+            const description = fs.readFileSync('pr_description.txt', 'utf8');
+
+            const currentPR = await github.rest.pulls.get({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            pull_number: context.payload.pull_request.number
+            });
+
+            let combinedDescription;
+            if (currentPR.data.body === null) {
+              combinedDescription = description;
+            } else {
+              combinedDescription = currentPR.data.body + '\n\n' + description;
+            }
+
+            await github.rest.issues.update({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            issue_number: context.payload.pull_request.number,
+            body: combinedDescription
+            });

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -6,63 +6,65 @@ on:
     tags:
       - '[0-9]+.[0-9]+.[0-9]+'
 
+env:
+  JAVA_VERSION: 17
 
 jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Calculate Helm release version from CHANGELOG
         run: echo HELM_VERSION=$(cat charts/traceability-foss/CHANGELOG.md | sed -n 's/.*\[\([0-9]\+\.[0-9]\+\.[0-9]\+\)\].*/\1/p' | head -n 1) >> $GITHUB_ENV
 
       - name: Update Chart.yaml appVersion
-        uses: mikefarah/yq@v4.35.2
+        uses: mikefarah/yq@v4.44.2
         with:
           cmd: yq -i eval '.appVersion = "${{ github.ref_name }}"' charts/traceability-foss/Chart.yaml
 
       - name: Update Chart.yaml version
-        uses: mikefarah/yq@v4.35.2
+        uses: mikefarah/yq@v4.44.2
         with:
           cmd: yq -i eval '.version = "${{ env.HELM_VERSION }}"' charts/traceability-foss/Chart.yaml
 
       - name: Update frontend dependency version in Chart.yaml
-        uses: mikefarah/yq@v4.35.2
+        uses: mikefarah/yq@v4.44.2
         with:
           cmd: yq -i eval '.dependencies[0].version = "${{ env.HELM_VERSION }}"' charts/traceability-foss/Chart.yaml
 
       - name: Update backend dependency version in Chart.yaml
-        uses: mikefarah/yq@v4.35.2
+        uses: mikefarah/yq@v4.44.2
         with:
           cmd: yq -i eval '.dependencies[1].version = "${{ env.HELM_VERSION }}"' charts/traceability-foss/Chart.yaml
 
       - name: Update frontend version in frontend/Chart.yaml
-        uses: mikefarah/yq@v4.35.2
+        uses: mikefarah/yq@v4.44.2
         with:
           cmd: yq -i eval '.version = "${{ env.HELM_VERSION }}"' charts/traceability-foss/charts/frontend/Chart.yaml
 
       - name: Update frontend appVersion in frontend/Chart.yaml
-        uses: mikefarah/yq@v4.35.2
+        uses: mikefarah/yq@v4.44.2
         with:
           cmd: yq -i eval '.appVersion = "${{ github.ref_name }}"' charts/traceability-foss/charts/frontend/Chart.yaml
 
       - name: Update backend version in backend/Chart.yaml
-        uses: mikefarah/yq@v4.35.2
+        uses: mikefarah/yq@v4.44.2
         with:
           cmd: yq -i eval '.version = "${{ env.HELM_VERSION }}"' charts/traceability-foss/charts/backend/Chart.yaml
 
       - name: Update backend appVersion in frontend/Chart.yaml
-        uses: mikefarah/yq@v4.35.2
+        uses: mikefarah/yq@v4.44.2
         with:
           cmd: yq -i eval '.appVersion = "${{ github.ref_name }}"' charts/traceability-foss/charts/backend/Chart.yaml
 
       - name: Update the frontend package.json appVersion
         run: |
-          npm install -g json
-          json -I -f frontend/package.json -e "this.version='${{ github.ref_name }}'"
+          sudo npm install -g json
+          sudo json -I -f frontend/package.json -e "this.version='${{ github.ref_name }}'"
 
       - name: Prepare Helm release
-        uses: peter-evans/create-pull-request@v5
+        uses: peter-evans/create-pull-request@v6
         with:
           commit-message: "chore(release): Prepare release for Helm version ${{ env.HELM_VERSION }}"
           branch: chore/prepare-helm-release-${{ env.HELM_VERSION }}
@@ -75,7 +77,7 @@ jobs:
             for this release. Also, make sure that the values.yaml is correct before merging this PR.
 
       - name: Get previous version
-        run: echo PREVIOUS_VERSION=$(git tag | grep -E ^[0-9]+\\.[0-9]+\\.[0-9]+ | tail -2 | head -n +1) >> $GITHUB_ENV
+        run: echo PREVIOUS_VERSION=$(git tag | grep -E ^[0-9]+\.[0-9]+\.[0-9]+ | tail -2 | head -n +1) >> $GITHUB_ENV
 
       - name: Extract changelog text
         # See: https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#multiline-strings
@@ -87,14 +89,6 @@ jobs:
           echo "$EOF" >> "$GITHUB_ENV"
 
       - name: Create Trace-X Release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         with:
           body: ${{ env.CHANGELOG }}
-
-  trigger-jira:
-    needs:
-      - release
-    uses: ./.github/workflows/jira-publish-release.yaml
-    with:
-      version: ${{ github.ref_name }}
-    secrets: inherit

--- a/.github/workflows/sonar-scan-backend.yml
+++ b/.github/workflows/sonar-scan-backend.yml
@@ -16,7 +16,9 @@
 #  SPDX-License-Identifier: Apache-2.0
 
 name: "[BE][SECURITY] Sonar"
+
 on:
+  pull_request:
   workflow_dispatch:
   push:
     paths:
@@ -24,40 +26,60 @@ on:
     branches:
       - main
   schedule:
-    - cron: "0 0 * * *"
+     - cron: "0 0 * * *"
 
 env:
   JAVA_VERSION: 17
 
 jobs:
-  build:
-    name: Build
+  Test-and-Sonar:
+    permissions:
+      contents: read
+      checks: write
+      pull-requests: write
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
-
-      - uses: actions/setup-java@v3
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/setup-java@v4
         with:
           java-version: '${{ env.JAVA_VERSION }}'
           distribution: 'temurin'
           cache: 'maven'
 
+      - name: Run unit & integration tests
+        run: |
+          mvn -pl tx-models,tx-backend,tx-coverage -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn -B verify -s settings.xml -DPACKAGES_ACCESS_USERNAME=${{ secrets.PACKAGES_ACCESS_USERNAME }} -DPACKAGES_ACCESS_TOKEN=${{ secrets.PACKAGES_ACCESS_TOKEN }}
+
+      - name: Publish integration test results
+        uses: EnricoMi/publish-unit-test-result-action@v2
+        if: always()
+        with:
+          files: "${{ github.workspace }}/tx-backend/target/failsafe-reports/TEST-*.xml"
+          check_name: "Integration Test Results"
+
+      - name: Publish unit test results
+        uses: EnricoMi/publish-unit-test-result-action@v2
+        if: always()
+        with:
+          files: "**/surefire-reports/TEST-*.xml"
+          check_name: "Unit Test Results"
+
+      - name: Clean working directories
+        run: |
+          rm -rf .scannerwork
+          rm -rf .sonar
+
       - name: Cache SonarCloud packages
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/.sonar/cache
           key: ${{ runner.os }}-sonar
           restore-keys: ${{ runner.os }}-sonar
 
-      - name: Run unit & integration tests
-        run: mvn -pl tx-models,tx-backend,tx-coverage -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn -B verify
-
       - name: Verify Sonar Scan
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN_BACKEND }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN_BACKEND  }}
           SONAR_ORGANIZATION: ${{ vars.SONAR_ORGANIZATION }}
           SONAR_PROJECT_KEY: ${{ vars.SONAR_PROJECT_KEY_BACKEND }}
-        run: mvn -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn --batch-mode sonar:sonar -Dsonar.coverage.jacoco.xmlReportPaths=/home/runner/work/tx-traceability-foss/tx-traceability-foss/tx-coverage/target/site/jacoco-aggregate/jacoco.xml -Dsonar.projectKey=${{ vars.SONAR_PROJECT_KEY_BACKEND }} -Dsonar.organization=${{ vars.SONAR_ORGANIZATION }}
+        run: mvn -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn --batch-mode sonar:sonar -Dsonar.coverage.jacoco.xmlReportPaths=${{ github.workspace }}/tx-coverage/target/site/jacoco-aggregate/jacoco.xml -Dsonar.projectKey=${{ vars.SONAR_PROJECT_KEY_BACKEND }} -Dsonar.organization=${{ vars.SONAR_ORGANIZATION }}

--- a/.github/workflows/sonar-scan-frontend.yml
+++ b/.github/workflows/sonar-scan-frontend.yml
@@ -21,6 +21,7 @@ on:
   push:
     branches: [ main ]
   workflow_dispatch:
+  pull_request:
   schedule:
     - cron: "0 0 * * *"
 
@@ -33,9 +34,9 @@ jobs:
         working-directory: frontend
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - name: Use Node.js 18.x
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 18.x
       - name: Install chrome

--- a/.github/workflows/spotbugs.yml
+++ b/.github/workflows/spotbugs.yml
@@ -44,20 +44,21 @@ jobs:
 
     name: spotbugs-check
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: '17'
           distribution: 'temurin'
 
       - name: Cache maven packages
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/.m2
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
           restore-keys: ${{ runner.os }}-m2
 
       - name: run maven spotbugs plugin
-        run: mvn clean package -pl tx-models,tx-backend  -DskipTests=true -Pspotbugs-check spotbugs:check
+        run: |
+          mvn clean package -pl tx-models,tx-backend -DskipTests=true -Pspotbugs-check spotbugs:check -s settings.xml -DPACKAGES_ACCESS_USERNAME=${{ secrets.PACKAGES_ACCESS_USERNAME }} -DPACKAGES_ACCESS_TOKEN=${{ secrets.PACKAGES_ACCESS_TOKEN }}

--- a/.github/workflows/testdata-upload.yaml
+++ b/.github/workflows/testdata-upload.yaml
@@ -1,0 +1,108 @@
+#    Copyright (c) 2023, 2024 Contributors to the Eclipse Foundation
+#
+#    See the NOTICE file(s) distributed with this work for additional
+#    information regarding copyright ownership.
+#
+#    This program and the accompanying materials are made available under the
+#    terms of the Apache License, Version 2.0 which is available at
+#    https://www.apache.org/licenses/LICENSE-2.0.
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+#
+#  SPDX-License-Identifier: Apache-2.0
+
+# For most projects, this workflow file will not need changing; you simply need
+# to commit it to your repository.
+#
+# You may wish to alter this file to override the set of languages analyzed,
+# or to provide custom queries or build logic.
+#
+name: Testdata import
+
+on:
+  workflow_dispatch:
+    inputs:
+      environment:
+        type: choice
+        description: Which Environment
+        required: true
+        options:
+          - Dev/Test
+          - E2E-A/E2E-B
+          - int-a/int-b
+          - association int-a/int-b
+
+      testdata_version:
+        description: Which Testdata Version CX_Testdata_MessagingTest_v<X.X.X>.json e.g., 0.0.14"
+        required: true
+
+
+jobs:
+  test_input:
+    runs-on: ubuntu-latest
+    steps:
+
+      - name: Checkout-Repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      - name: Check Testdata Version Format
+        run: |
+          if [[ ! "${{ github.event.inputs.testdata_version }}" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9]+)?$ ]]; then
+           echo "Invalid Testdata Version format. Please use X.X.X or X.X.X-suffix, e.g., 1.1.12"
+           exit 1
+          fi
+
+  print_environment:
+    needs: test_input
+    runs-on: ubuntu-latest
+    steps:
+      - name: ${{ github.event.inputs.environment }}
+        run: |
+          echo "### inputs" >> $GITHUB_STEP_SUMMARY
+          echo "- environment: ${{ github.event.inputs.environment }}" >> $GITHUB_STEP_SUMMARY
+          echo "- test data version: ${{ github.event.inputs.testdata_version }}" >> $GITHUB_STEP_SUMMARY
+
+
+  upload_testdata:
+    needs: test_input
+    runs-on: ubuntu-latest
+    steps:
+
+      - name: Checkout code
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Upload testdata
+        run: |
+          python -m pip install requests
+          curl -o transform-and-upload.py https://raw.githubusercontent.com/eclipse-tractusx/item-relationship-service/main/local/testing/testdata/transform-and-upload.py
+            if [ "${{ github.event.inputs.environment }}" == "Dev/Test" ]; then
+                  python transform-and-upload.py -f ./tx-backend/testdata/CX_Testdata_MessagingTest_v${{ github.event.inputs.testdata_version }}.json -s https://tracex-test-submodel-server.dev.demo.catena-x.net -edc https://trace-x-test-edc.dev.demo.catena-x.net -a https://trace-x-registry-test.dev.demo.catena-x.net/semantics/registry/api/v3 -d https://trace-x-test-edc-dataplane.dev.demo.catena-x.net -p traceability-core -k ${{ secrets.TRACE_X_API_KEY_DEV }} --aas3 --edcBPN BPNL00000003CNKC --allowedBPNs BPNL00000003CML1 BPNL00000003CNKC
+              sleep 10
+                  python transform-and-upload.py -f ./tx-backend/testdata/CX_Testdata_MessagingTest_v${{ github.event.inputs.testdata_version }}.json -s https://tracex-dev-submodel-server.dev.demo.catena-x.net -edc https://trace-x-edc.dev.demo.catena-x.net -a https://trace-x-registry-dev.dev.demo.catena-x.net/semantics/registry/api/v3 -d https://trace-x-edc-dataplane.dev.demo.catena-x.net -p traceability-core -k ${{ secrets.TRACE_X_API_KEY_DEV }} --aas3 --edcBPN BPNL00000003CML1 --allowedBPNs BPNL00000003CML1 BPNL00000003CNKC
+              sleep 10
+            elif [ "${{ github.event.inputs.environment }}" == "E2E-A/E2E-B" ]; then
+                  python transform-and-upload.py -f ./tx-backend/testdata/CX_Testdata_MessagingTest_v${{ github.event.inputs.testdata_version }}.json -s https://tracex-e2e-a-submodel-server.dev.demo.catena-x.net -edc https://trace-x-edc-e2e-a.dev.demo.catena-x.net -a https://trace-x-registry-e2e-a.dev.demo.catena-x.net/semantics/registry/api/v3 -d https://trace-x-edc-e2e-a-dataplane.dev.demo.catena-x.net -p traceability-core -k ${{ secrets.TRACE_X_API_KEY_DEV }} --aas3 --edcBPN BPNL00000003CML1 --allowedBPNs BPNL00000003CML1 BPNL00000003CNKC
+              sleep 10
+                  python transform-and-upload.py -f ./tx-backend/testdata/CX_Testdata_MessagingTest_v${{ github.event.inputs.testdata_version }}.json -s https://tracex-e2e-b-submodel-server.dev.demo.catena-x.net -edc https://trace-x-edc-e2e-b.dev.demo.catena-x.net -a https://trace-x-registry-e2e-b.dev.demo.catena-x.net/semantics/registry/api/v3 -d https://trace-x-edc-e2e-b-dataplane.dev.demo.catena-x.net -p traceability-core -k ${{ secrets.TRACE_X_API_KEY_DEV }} --aas3 --edcBPN BPNL00000003CNKC --allowedBPNs BPNL00000003CML1 BPNL00000003CNKC
+              sleep 10
+            elif [ "${{ github.event.inputs.environment }}" == "int-a/int-b" ]; then
+                  python transform-and-upload.py -f ./tx-backend/testdata/CX_Testdata_MessagingTest_v${{ github.event.inputs.testdata_version }}.json -s https://tracex-int-a-submodel-server.int.demo.catena-x.net -edc https://trace-x-edc-int-a.int.demo.catena-x.net -a https://trace-x-registry-int-a.int.demo.catena-x.net/semantics/registry/api/v3 -d https://trace-x-edc-int-a-dataplane.int.demo.catena-x.net -p traceability-core -k ${{ secrets.TRACE_X_API_KEY_INT_A }} --aas3 --edcBPN BPNL00000003CML1 --allowedBPNs BPNL00000003CML1 BPNL00000003CNKC BPNL00000003AZQP BPNL00000003CSGV
+              sleep 10
+                  python transform-and-upload.py -f ./tx-backend/testdata/CX_Testdata_MessagingTest_v${{ github.event.inputs.testdata_version }}.json -s https://tracex-int-b-submodel-server.int.demo.catena-x.net -edc https://trace-x-edc-int-b.int.demo.catena-x.net -a https://trace-x-registry-int-b.int.demo.catena-x.net/semantics/registry/api/v3 -d https://trace-x-edc-int-b-dataplane.int.demo.catena-x.net -p traceability-core -k ${{ secrets.TRACE_X_API_KEY_INT_B }} --aas3 --edcBPN BPNL00000003CNKC --allowedBPNs BPNL00000003CML1 BPNL00000003CNKC BPNL00000003AZQP BPNL00000003CSGV
+              sleep 10
+            elif [ "${{ github.event.inputs.environment }}" == "association int-a/int-b" ]; then
+                  python transform-and-upload.py -f ./tx-backend/testdata/CX_Testdata_MessagingTest_v${{ github.event.inputs.testdata_version }}.json -s https://tracex-int-a-submodel-server.int.catena-x.net -edc https://trace-x-edc-int-a.int.catena-x.net -a https://trace-x-registry-int-a.int.catena-x.net/semantics/registry/api/v3 -d https://trace-x-edc-int-a-dataplane.int.catena-x.net -p traceability-core -k ${{ secrets.TRACE_X_API_KEY_ASSOCIATION_INT }} --aas3 --edcBPN BPNL000000000UKM --allowedBPNs BPNL000000000UKM BPNL000000000DWF BPNL00000003AZQP BPNL00000003CSGV
+              sleep 10
+                  python transform-and-upload.py -f ./tx-backend/testdata/CX_Testdata_MessagingTest_v${{ github.event.inputs.testdata_version }}.json -s https://tracex-int-b-submodel-server.int.catena-x.net -edc https://trace-x-edc-int-b.int.catena-x.net -a https://trace-x-registry-int-b.int.catena-x.net/semantics/registry/api/v3 -d https://trace-x-edc-int-b-dataplane.int.catena-x.net -p traceability-core -k ${{ secrets.TRACE_X_API_KEY_ASSOCIATION_INT }} --aas3 --edcBPN BPNL000000000DWF --allowedBPNs BPNL000000000DWF BPNL000000000UKM BPNL00000003AZQP BPNL00000003CSGV
+              sleep 10
+            fi
+

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -63,17 +63,18 @@ jobs:
     runs-on: ubuntu-latest
     defaults:
       run:
-        working-directory: frontend
+        working-directory: .
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Build an image from Dockerfile
-        run: docker build -t localhost:5000/traceability-foss:fe_${{ github.sha }} .
+        run: docker build -t localhost:5000/traceability-foss:fe_${{ github.sha }} -f ./frontend/Dockerfile .
 
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@0.12.0
+        uses: aquasecurity/trivy-action@0.30.0
         with:
+          trivyignores: "./.github/workflows/.trivyignore"
           image-ref: 'localhost:5000/traceability-foss:fe_${{ github.sha }}'
           format: "sarif"
           limit-severities-for-sarif: true
@@ -81,7 +82,7 @@ jobs:
           severity: 'CRITICAL,HIGH'
 
       - name: Upload Trivy scan results to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: 'trivy-results.sarif'
 
@@ -94,7 +95,7 @@ jobs:
       check_sha: ${{ steps.step1.outputs.check_sha }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           ref: ${{needs.prepare-env.outputs.check_sha}}
       - name: Set commit SHA to check
@@ -126,13 +127,14 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           ref: ${{needs.prepare-env.outputs.check_sha}}
 
       - name: Run Trivy vulnerability scanner in repo mode
-        uses: aquasecurity/trivy-action@0.12.0
+        uses: aquasecurity/trivy-action@0.30.0
         with:
+          trivyignores: "./.github/workflows/.trivyignore"
           scan-type: "config"
           hide-progress: false
           format: "sarif"
@@ -141,7 +143,7 @@ jobs:
           timeout: "10m0s"
 
       - name: Upload Trivy scan results to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@v3
         if: always()
         with:
           sarif_file: "trivy-results1.sarif"
@@ -160,23 +162,25 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
-      - uses: actions/setup-java@v3
+      - uses: actions/setup-java@v4
         with:
           java-version: '${{ env.JAVA_VERSION }}'
           distribution: 'temurin'
           cache: 'maven'
 
       - name: Locally build docker image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
           context: .
           push: false
+          file: "./Dockerfile"
           tags: localhost:5000/traceability-foss:trivy
+          build-args: "ARGS=${{ secrets.PACKAGES_ACCESS_USERNAME }},${{ secrets.PACKAGES_ACCESS_TOKEN }}"
 
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@0.12.0
+        uses: aquasecurity/trivy-action@0.30.0
         with:
           image-ref: localhost:5000/traceability-foss:trivy
           trivyignores: "./.github/workflows/.trivyignore"
@@ -188,7 +192,7 @@ jobs:
 
       - name: Upload Trivy scan results to GitHub Security tab
         if: always()
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: "trivy-results2.sarif"
 

--- a/.github/workflows/trufflehog-secret-scan.yml
+++ b/.github/workflows/trufflehog-secret-scan.yml
@@ -1,0 +1,60 @@
+#
+# Copyright (c) 2024 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License, Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0.
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+name: "TruffleHog"
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    # The branches below must be a subset of the branches above
+    branches: ["main"]
+  schedule:
+    - cron: "0 0 * * *" # Once a day
+  workflow_dispatch:
+
+permissions:
+  actions: read
+  contents: read
+  security-events: write
+  id-token: write
+  issues: write
+
+jobs:
+  ScanSecrets:
+    name: Scan secrets
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          fetch-depth: 0  # Ensure full clone for pull request workflows
+
+      - name: TruffleHog OSS
+        id: trufflehog
+        uses: trufflesecurity/trufflehog@690e5c7aff8347c3885096f3962a0633d9129607 #v3.88.23
+        continue-on-error: true
+        with:
+          path: ./  # Scan the entire repository
+          base: "${{ github.event.repository.default_branch }}"  # Set base branch for comparison (pull requests)
+          extra_args: --filter-entropy=4 --results=verified,unknown --debug
+
+      - name: Scan Results Status
+        if: steps.trufflehog.outcome == 'failure'
+        run: exit 1  # Set workflow run to failure if TruffleHog finds secrets

--- a/.github/workflows/unit-test_frontend.yml
+++ b/.github/workflows/unit-test_frontend.yml
@@ -23,6 +23,7 @@ on:
     paths:
       - 'frontend/**'
   pull_request:
+  workflow_dispatch:
 
 jobs:
   build:
@@ -33,9 +34,9 @@ jobs:
         working-directory: frontend
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
     - name: Use Node.js 18.x
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v4
       with:
         node-version: 18.x
     - name: Install chrome
@@ -46,13 +47,3 @@ jobs:
       run: yarn install
     - name: Run yarn test:ci
       run: CHROMIUM_BIN=$(which chrome) yarn test:ci # will run `test:ci` command
-    - name: Run SonarCloud check
-      uses: SonarSource/sonarcloud-github-action@master
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
-        SONAR_TOKEN: ${{ secrets.SONAR_TOKEN_FRONTEND }}
-      with:
-        projectBaseDir: frontend
-        args: >
-          -Dsonar.organization=${{ vars.SONAR_ORGANIZATION }}
-          -Dsonar.projectKey=${{ vars.SONAR_PROJECT_KEY_FRONTEND }}

--- a/.github/workflows/update-helm-environment.yml
+++ b/.github/workflows/update-helm-environment.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout 🛎
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           # check out all branches
           fetch-depth: 0

--- a/.github/workflows/update-openapi-spec.yml
+++ b/.github/workflows/update-openapi-spec.yml
@@ -1,0 +1,37 @@
+name: "Update OpenAPI spec"
+
+on:
+  workflow_dispatch:
+
+jobs:
+  update-spec:
+    runs-on: ubuntu-latest
+    env:
+      SWAGGERHUB_API_KEY: ${{ secrets.SWAGGERHUB_API_KEY }}
+      SWAGGERHUB_USER: ${{ secrets.SWAGGERHUB_USER }}
+      SPEC_FILE: docs/api/traceability-foss-backend.json
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+          cache: 'maven'
+
+      - name: Update OpenAPI spec
+        run: mvn test -B -Dsurefire.failIfNoSpecifiedTests=false -Dtest=OpenApiDocumentationIT -Dopenapi-doc.generate=true
+
+      - name: Create pull request for OpenAPI spec update
+        uses: peter-evans/create-pull-request@v7
+        with:
+          commit-message: "chore(release): updated OpenAPI spec"
+          branch: chore/update-openapi-spec
+          base: main
+          delete-branch: true
+          title: "chore: update OpenAPI spec"
+          body: |
+            This PR updates the OpenAPI spec. Please check whether the update was performed correctly. Unfortunately, this
+            action causes a lot of unnecessary changes which should, however, be clearly recognizable as such.
+            You may safely ignore these.

--- a/.github/workflows/xray-cucumber-association.yaml
+++ b/.github/workflows/xray-cucumber-association.yaml
@@ -1,4 +1,4 @@
-#    Copyright (c) 2023 Contributors to the Eclipse Foundation
+#    Copyright (c) 2024 Contributors to the Eclipse Foundation
 #
 #    See the NOTICE file(s) distributed with this work for additional
 #    information regarding copyright ownership.
@@ -15,7 +15,7 @@
 #
 #  SPDX-License-Identifier: Apache-2.0
 
-name: "[BE][TEST][E2E] Cucumber"
+name: "[BE][TEST][E2E] Cucumber - Association"
 
 on:
   workflow_dispatch: # Trigger manually
@@ -45,12 +45,19 @@ jobs:
       - name: Download Feature Files
         id: download
         env:
-          JIRA_USERNAME: ${{ secrets.ORG_IRS_JIRA_USERNAME }}
-          JIRA_PASSWORD: ${{ secrets.ORG_IRS_JIRA_PASSWORD }}
+          JIRA_USERNAME: ${{ secrets.ASSOCIATION_TX_JIRA_USERNAME }}
+          JIRA_PASSWORD: ${{ secrets.ASSOCIATION_TX_JIRA_PASSWORD }}
+        working-directory: tx-cucumber-tests
           # JIRA filter 11349: project = "[TR] FOSS - Open Source (Impl.)" AND issuetype = Test AND "Test Type" = Cucumber AND status = Ready AND labels = INTEGRATION_TEST AND (environment ~ DEV OR environment ~ "INT")
           # Downloads all feature files of cucumber tests inside TRI project
         run: |
-          export HTTP_RESULT=$(curl -s --show-error -w "%{http_code}" -u $JIRA_USERNAME:$JIRA_PASSWORD "https://jira.catena-x.net/rest/raven/1.0/export/test?filter=11711&fz=true" -o tx-cucumber-tests/features.zip)
+          token=$(curl -H "Content-Type: application/json" -X POST \
+          --data "{ \"client_id\": \"$JIRA_USERNAME\",\"client_secret\": \"$JIRA_PASSWORD\" }" \
+          https://xray.cloud.getxray.app/api/v2/authenticate | tr -d '"')
+
+          export HTTP_RESULT=$(curl -s --show-error -w "%{http_code}" --header "Authorization: Bearer $token" \
+          "https://xray.cloud.getxray.app/api/v2/export/cucumber?filter=10005&fz=true" -o features.zip)
+
           [[ $HTTP_RESULT == 200 || $HTTP_RESULT == 400 ]]
           echo "::set-output name=http_response::$HTTP_RESULT"
 
@@ -60,31 +67,36 @@ jobs:
       # Required step due to fact that jira will name feature files differently with each feature added and that will cause duplicate test runs
       - name: Cleanup repository feature files
         if: ${{ steps.download.outputs.http_response == '200' }}
-        #working-directory: tx-cucumber-tests
+        working-directory: tx-cucumber-tests
         run: |
-          rm -r tx-cucumber-tests/src/test/resources/features/*
+          rm -r src/test/resources/features/*
 
       - name: Build with Maven
         if: ${{ steps.download.outputs.http_response == '200' }}
         env:
-          KEYCLOAK_HOST: ${{ secrets.KEYCLOAK_HOST }}
-          SUPERVISOR_CLIENT_ID: ${{ secrets.SUPERVISOR_CLIENT_ID }}
-          SUPERVISOR_PASSWORD: ${{ secrets.SUPERVISOR_PASSWORD }}
-          E2E_TXA_HOST: ${{ secrets.E2E_TXA_HOST }}
-          E2E_TXB_HOST: ${{ secrets.E2E_TXB_HOST }}
-        #working-directory: tx-cucumber-tests
+          ASSOCIATION_KEYCLOAK_HOST: ${{ secrets.ASSOCIATION_KEYCLOAK_HOST }}
+          ASSOCIATION_SUPERVISOR_TX_A_CLIENT_ID: ${{ secrets.ASSOCIATION_SUPERVISOR_TX_A_CLIENT_ID }}
+          ASSOCIATION_SUPERVISOR_TX_A_PASSWORD: ${{ secrets.ASSOCIATION_SUPERVISOR_TX_A_PASSWORD }}
+          ASSOCIATION_SUPERVISOR_TX_B_CLIENT_ID: ${{ secrets.ASSOCIATION_SUPERVISOR_TX_B_CLIENT_ID }}
+          ASSOCIATION_SUPERVISOR_TX_B_PASSWORD: ${{ secrets.ASSOCIATION_SUPERVISOR_TX_B_PASSWORD }}
+          ASSOCIATION_E2E_TXA_HOST: ${{ secrets.ASSOCIATION_E2E_TXA_HOST }}
+          ASSOCIATION_E2E_TXB_HOST: ${{ secrets.ASSOCIATION_E2E_TXB_HOST }}
         run: |
           unzip -o tx-cucumber-tests/features.zip -d tx-cucumber-tests/src/test/resources/features
-          mvn -pl tx-models,tx-cucumber-tests --batch-mode clean install  -D"cucumber.filter.tags"="not @Ignore and @INTEGRATION_TEST"
+          mvn -pl tx-models,tx-cucumber-tests --batch-mode clean install  -D"cucumber.filter.tags"="@trace-x-automated" -P association
 
       - name: Submit results to Xray
         if: ${{ always() && steps.download.outputs.http_response == '200' }}
         env:
-          JIRA_USERNAME: ${{ secrets.ORG_IRS_JIRA_USERNAME }}
-          JIRA_PASSWORD: ${{ secrets.ORG_IRS_JIRA_PASSWORD }}
+          JIRA_USERNAME: ${{ secrets.ASSOCIATION_TX_JIRA_USERNAME }}
+          JIRA_PASSWORD: ${{ secrets.ASSOCIATION_TX_JIRA_PASSWORD }}
         run: |
+          token=$(curl -H "Content-Type: application/json" -X POST \
+          --data "{ \"client_id\": \"$JIRA_USERNAME\",\"client_secret\": \"$JIRA_PASSWORD\" }" \
+          https://xray.cloud.getxray.app/api/v2/authenticate | tr -d '"')
+
           curl --request POST \
-          -u $JIRA_USERNAME:$JIRA_PASSWORD \
           --header 'Content-Type: application/json' \
+          --header "Authorization: Bearer $token" \
           --data-binary '@tx-cucumber-tests/report.json' \
-          "https://jira.catena-x.net/rest/raven/1.0/import/execution/cucumber"
+          "https://xray.cloud.getxray.app/api/v2/import/execution/cucumber"


### PR DESCRIPTION
## Description

This PR "migrates" the used version (without any upgrade) for checkout action to SHA. NO upgrade is done.
The SHA values can be found [here](https://github.com/actions/checkout/releases)

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [ ] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [ ] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files